### PR TITLE
Boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,20 @@ composer require spatie/period
 
 ```php
 $period = new Period(
-     DateTimeImmutable::createFromFormat(/* … */)
-   , DateTimeImmutable::createFromFormat(/* … */)
-  [, Precision::DAY]
-  [, Boundaries::EXCLUDE_NONE]
+     DateTimeImmutable $start
+   , DateTimeImmutable $end
+  [, int $precisionMask = Precision::DAY]
+  [, int $boundaryExclusionMask = Boundaries::EXCLUDE_NONE]
 )
 ```
 
-The static `::make` constructor can also take strings as dates:
+The static `::make` constructor can also take strings and other implementations of `DateTimeInterface`, 
+as well as an extra format string, in case the textual dates passed aren't of the format `Y-m-d` or `Y-m-d H:i:s`. 
 
 ```php
 $period = Period::make(
-     '2018-01-01'
-   , '2018-01-31'
+     string|DateTimeInterface $start
+   , string|DateTimeInterface $end
   [, int Precision::DAY]
   [, int Boundaries::EXCLUDE_NONE]
   [, string $format]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ composer require spatie/period
 
 ## Usage
 
-### Creating a period
+### Quick reference
+
+#### Creating a period
 
 ```php
 $period = new Period(
@@ -49,7 +51,68 @@ $period = Period::make(
   [, ?int Boundaries::EXCLUDE_NONE]
   [, string $format]
 )
-```  
+```
+
+#### Length and boundaries
+
+```php
+$period->length(): int;
+```
+
+```php
+$period->startIncluded(): bool;
+$period->startExcluded(): bool;
+$period->endIncluded(): bool;
+$period->endExcluded(): bool;
+```
+
+```php
+$period->getStart(): DateTimeImmutable;
+$period->getStartIncluded(): DateTimeImmutable;
+$period->getEnd(): DateTimeImmutable;
+$period->getEndIncluded(): DateTimeImmutable;
+```
+
+#### Comparisons
+
+```php
+$period->contains(DateTimeInterface $date): bool
+$period->equals(Period $period): bool
+
+$period->overlapsWith(Period $period): bool
+$period->touchesWith(Period $period): bool
+```
+
+```php
+$period->startsAt(DateTimeInterface $date): bool
+$period->startsBefore(DateTimeInterface $date): bool
+$period->startsBeforeOrAt(DateTimeInterface $date): bool
+$period->startsAfter(DateTimeInterface $date): bool
+$period->startsAfterOrAt(DateTimeInterface $date): bool
+```
+
+```php
+$period->endsAt(DateTimeInterface $date): bool
+$period->endsBefore(DateTimeInterface $date): bool
+$period->endsBeforeOrAt(DateTimeInterface $date): bool
+$period->endsAfter(DateTimeInterface $date): bool
+$period->endsAfterOrAt(DateTimeInterface $date): bool
+```
+
+```php
+$period->gap(Period $period): ?Period
+```
+
+```php
+$period->overlapSingle(Period $period): ?Period
+$period->overlap(Period ...$periods): PeriodCollection
+$period->overlapAll(Period ...$periods): Period
+```
+
+```php
+$period->diffSingle(Period $period): PeriodCollection
+$period->diff(Period ...$periods): PeriodCollection
+```
 
 ### Comparing periods
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ composer require spatie/period
 $period = new Period(
      DateTimeImmutable $start
    , DateTimeImmutable $end
-  [, int $precisionMask = Precision::DAY]
-  [, int $boundaryExclusionMask = Boundaries::EXCLUDE_NONE]
+  [, ?int $precisionMask = Precision::DAY]
+  [, ?int $boundaryExclusionMask = Boundaries::EXCLUDE_NONE]
 )
 ```
 
@@ -45,8 +45,8 @@ as well as an extra format string, in case the textual dates passed aren't of th
 $period = Period::make(
      string|DateTimeInterface $start
    , string|DateTimeInterface $end
-  [, int Precision::DAY]
-  [, int Boundaries::EXCLUDE_NONE]
+  [, ?int Precision::DAY]
+  [, ?int Boundaries::EXCLUDE_NONE]
   [, string $format]
 )
 ```  

--- a/README.md
+++ b/README.md
@@ -56,21 +56,21 @@ $period = Period::make(
 #### Length and boundaries
 
 ```php
-$period->length(): int;
+$period->length(): int
 ```
 
 ```php
-$period->startIncluded(): bool;
-$period->startExcluded(): bool;
-$period->endIncluded(): bool;
-$period->endExcluded(): bool;
+$period->startIncluded(): bool
+$period->startExcluded(): bool
+$period->endIncluded(): bool
+$period->endExcluded(): bool
 ```
 
 ```php
-$period->getStart(): DateTimeImmutable;
-$period->getStartIncluded(): DateTimeImmutable;
-$period->getEnd(): DateTimeImmutable;
-$period->getEndIncluded(): DateTimeImmutable;
+$period->getStart(): DateTimeImmutable
+$period->getStartIncluded(): DateTimeImmutable
+$period->getEnd(): DateTimeImmutable
+$period->getEndIncluded(): DateTimeImmutable
 ```
 
 #### Comparisons
@@ -112,6 +112,19 @@ $period->overlapAll(Period ...$periods): Period
 ```php
 $period->diffSingle(Period $period): PeriodCollection
 $period->diff(Period ...$periods): PeriodCollection
+```
+
+```php
+$periodCollection->overlap(PeriodCollection ...$periodCollections): PeriodCollection
+$periodCollection->overlapSingle(PeriodCollection $periodCollection): PeriodCollection
+```
+
+```php
+$periodCollection->boundaries(): ?Period
+```
+
+```php
+$periodCollection->gaps(): PeriodCollection
 ```
 
 ### Comparing periods

--- a/README.md
+++ b/README.md
@@ -320,8 +320,8 @@ $a->length(); // 31
 It's possible to override the boundary behaviour:
 
 ```php
-$a = Period::make('2018-01-01', '2018-02-01', null, Period::EXCLUDE_END);
-$b = Period::make('2018-02-01', '2018-02-28', null, Period::EXCLUDE_END);
+$a = Period::make('2018-01-01', '2018-02-01', null, Boundaries::EXCLUDE_END);
+$b = Period::make('2018-02-01', '2018-02-28', null, Boundaries::EXCLUDE_END);
 
 $a->overlapsWith($b); // false
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,31 @@ composer require spatie/period
 
 ## Usage
 
+### Creating a period
+
+```php
+$period = new Period(
+     DateTimeImmutable::createFromFormat(/* … */)
+   , DateTimeImmutable::createFromFormat(/* … */)
+  [, Precision::DAY]
+  [, Boundaries::EXCLUDE_NONE]
+)
+```
+
+The static `::make` constructor can also take strings as dates:
+
+```php
+$period = Period::make(
+     '2018-01-01'
+   , '2018-01-31'
+  [, int Precision::DAY]
+  [, int Boundaries::EXCLUDE_NONE]
+  [, string $format]
+)
+```  
+
+### Comparing periods
+
 **Overlaps with any other period**: 
 this method returns a `PeriodCollection` multiple `Period` objects representing the overlaps.
 
@@ -239,6 +264,38 @@ And finally construct one collection from another:
 $newCollection = new PeriodCollection(...$otherCollection);
 ```
 
+### Precision
+
+Date precision is of utmost importance if you want to reliably compare two periods.
+The the following example:
+
+> Given two periods: `[2018-01-01, 2018-01-15]` and `[2018-01-15, 2018-01-31]`; do they overlap?
+
+At first glance the answer is "yes": they overlap on `2018-01-15`. 
+But what if the first period ends at `2018-01-15 10:00:00`, 
+while the second starts at `2018-01-15 15:00:00`? 
+Now they don't anymore!
+
+This is why this package requires you to specify a precision with each period. 
+Only periods with the same precision can be compared.
+
+A period's precision can be specified when constructing that period:
+
+```php
+Period::make('2018-01-01', '2018-02-01', Precision::DAY);
+```
+
+The default precision is set on days. These are the available precision options:
+
+```php
+Precision::YEAR
+Precision::MONTH
+Precision::DAY
+Precision::HOUR
+Precision::MINUTE
+Precision::SECOND
+```
+
 ### Boundaries
 
 By default, period comparisons are done with included boundaries. 
@@ -271,10 +328,10 @@ $a->overlapsWith($b); // false
 There are four types of boundary exclusion:
 
 ```php
-Period::EXCLUDE_NONE;
-Period::EXCLUDE_START;
-Period::EXCLUDE_END;
-Period::EXCLUDE_ALL;
+Boundaries::EXCLUDE_NONE;
+Boundaries::EXCLUDE_START;
+Boundaries::EXCLUDE_END;
+Boundaries::EXCLUDE_ALL;
 ```
 
 ### Compatibility

--- a/README.md
+++ b/README.md
@@ -239,6 +239,44 @@ And finally construct one collection from another:
 $newCollection = new PeriodCollection(...$otherCollection);
 ```
 
+### Boundaries
+
+By default, period comparisons are done with included boundaries. 
+This means that these two periods overlap:
+
+```php
+$a = Period::make('2018-01-01', '2018-02-01');
+$b = Period::make('2018-02-01', '2018-02-28');
+
+$a->overlapsWith($b); // true
+```
+
+The length of a period will also include both boundaries:
+
+```php
+$a = Period::make('2018-01-01', '2018-01-31');
+
+$a->length(); // 31
+```
+
+It's possible to override the boundary behaviour:
+
+```php
+$a = Period::make('2018-01-01', '2018-02-01', null, Period::EXCLUDE_END);
+$b = Period::make('2018-02-01', '2018-02-28', null, Period::EXCLUDE_END);
+
+$a->overlapsWith($b); // false
+```
+
+There are four types of boundary exclusion:
+
+```php
+Period::EXCLUDE_NONE;
+Period::EXCLUDE_START;
+Period::EXCLUDE_END;
+Period::EXCLUDE_ALL;
+```
+
 ### Compatibility
 
 You can construct a `Period` from any type of `DateTime` object such as Carbon:

--- a/src/Boundaries.php
+++ b/src/Boundaries.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\Period;
+
+interface Boundaries
+{
+    const EXCLUDE_NONE = 0;
+    const EXCLUDE_START = 2;
+    const EXCLUDE_END = 4;
+    const EXCLUDE_ALL = 6;
+}

--- a/src/Exceptions/CannotComparePeriods.php
+++ b/src/Exceptions/CannotComparePeriods.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Period\Exceptions;
+
+use Exception;
+
+class CannotComparePeriods extends Exception
+{
+    public static function precisionDoesNotMatch(): CannotComparePeriods
+    {
+        return new self("Cannot compare two periods whose precision doesn't match.");
+    }
+}

--- a/src/Period.php
+++ b/src/Period.php
@@ -6,9 +6,9 @@ use DateTime;
 use DateInterval;
 use DateTimeImmutable;
 use DateTimeInterface;
-use Spatie\Period\Exceptions\CannotComparePeriods;
 use Spatie\Period\Exceptions\InvalidDate;
 use Spatie\Period\Exceptions\InvalidPeriod;
+use Spatie\Period\Exceptions\CannotComparePeriods;
 
 class Period
 {

--- a/src/Period.php
+++ b/src/Period.php
@@ -60,8 +60,8 @@ class Period
     }
 
     /**
-     * @param $start
-     * @param $end
+     * @param string|DateTimeInterface $start
+     * @param string|DateTimeInterface $end
      * @param int|null $precisionMask
      * @param int|null $boundaryExclusionMask
      * @param string|null $format

--- a/src/Period.php
+++ b/src/Period.php
@@ -466,31 +466,16 @@ class Period
 
     protected function createDateInterval(int $precision): DateInterval
     {
-        if ((Precision::SECOND & $precision) === Precision::SECOND) {
-            return new DateInterval('PT1S');
-        }
+        $interval = [
+            Precision::SECOND => 'PT1S',
+            Precision::MINUTE => 'PT1M',
+            Precision::HOUR => 'PT1H',
+            Precision::DAY => 'P1D',
+            Precision::MONTH => 'P1M',
+            Precision::YEAR => 'P1Y',
+        ][$precision];
 
-        if ((Precision::MINUTE & $precision) === Precision::MINUTE) {
-            return new DateInterval('PT1M');
-        }
-
-        if ((Precision::HOUR & $precision) === Precision::HOUR) {
-            return new DateInterval('PT1H');
-        }
-
-        if ((Precision::DAY & $precision) === Precision::DAY) {
-            return new DateInterval('P1D');
-        }
-
-        if ((Precision::MONTH & $precision) === Precision::MONTH) {
-            return new DateInterval('P1M');
-        }
-
-        if ((Precision::YEAR & $precision) === Precision::YEAR) {
-            return new DateInterval('P1Y');
-        }
-
-        return new DateInterval('P1D');
+        return new DateInterval($interval);
     }
 
     protected function ensurePrecisionMatches(Period $period): void

--- a/src/Period.php
+++ b/src/Period.php
@@ -437,10 +437,7 @@ class Period
             return $format;
         }
 
-        if (
-            strpos($format, ' ') === false
-            && strpos($date, ' ') !== false
-        ) {
+        if (strpos($format, ' ') === false && strpos($date, ' ') !== false) {
             return 'Y-m-d H:i:s';
         }
 

--- a/src/Period.php
+++ b/src/Period.php
@@ -22,8 +22,11 @@ class Period
     /** @var \DateTimeImmutable */
     protected $end;
 
+    /** @var \DateInterval */
+    protected $interval;
+
     /** @var int */
-    protected $exclusionMask;
+    private $exclusionMask;
 
     public function __construct(
         DateTimeImmutable $start,
@@ -36,6 +39,7 @@ class Period
 
         $this->start = $start;
         $this->end = $end;
+        $this->interval = new DateInterval('P1D');
         $this->exclusionMask = $exclusionMask;
     }
 
@@ -137,23 +141,43 @@ class Period
         return $this->start;
     }
 
+    public function getIncludedStart(): DateTimeImmutable
+    {
+        if ($this->startIncluded()) {
+            return $this->start;
+        }
+
+        return $this->start->add($this->interval);
+    }
+
     public function getEnd(): DateTimeImmutable
     {
         return $this->end;
     }
 
+    public function getIncludedEnd(): DateTimeImmutable
+    {
+        if ($this->endIncluded()) {
+            return $this->end;
+        }
+
+        return $this->end->sub($this->interval);
+    }
+
     public function length(): int
     {
-        return $this->start->diff($this->end)->days + 1;
+        $length = $this->getIncludedStart()->diff($this->getIncludedEnd())->days + 1;
+
+        return $length;
     }
 
     public function overlapsWith(Period $period): bool
     {
-        if ($this->start > $period->end) {
+        if ($this->getIncludedStart() > $period->getIncludedEnd()) {
             return false;
         }
 
-        if ($period->start > $this->end) {
+        if ($period->getIncludedStart() > $this->getIncludedEnd()) {
             return false;
         }
 
@@ -162,11 +186,11 @@ class Period
 
     public function touchesWith(Period $period): bool
     {
-        if ($this->end->diff($period->start)->days <= 1) {
+        if ($this->getIncludedEnd()->diff($period->getIncludedStart())->days <= 1) {
             return true;
         }
 
-        if ($this->start->diff($period->end)->days <= 1) {
+        if ($this->getIncludedStart()->diff($period->getIncludedEnd())->days <= 1) {
             return true;
         }
 
@@ -175,7 +199,7 @@ class Period
 
     public function startsAfterOrAt(DateTimeInterface $date): bool
     {
-        return $this->start >= $date;
+        return $this->getIncludedStart() >= $date;
     }
 
     public function endsAfterOrAt(DateTimeInterface $date): bool
@@ -185,7 +209,7 @@ class Period
 
     public function startsBeforeOrAt(DateTimeInterface $date): bool
     {
-        return $this->start <= $date;
+        return $this->getIncludedStart() <= $date;
     }
 
     public function endsBeforeOrAt(DateTimeInterface $date): bool
@@ -195,7 +219,7 @@ class Period
 
     public function startsAfter(DateTimeInterface $date): bool
     {
-        return $this->start > $date;
+        return $this->getIncludedStart() > $date;
     }
 
     public function endsAfter(DateTimeInterface $date): bool
@@ -205,21 +229,21 @@ class Period
 
     public function startsBefore(DateTimeInterface $date): bool
     {
-        return $this->start < $date;
+        return $this->getIncludedStart() < $date;
     }
 
     public function endsBefore(DateTimeInterface $date): bool
     {
-        return $this->end < $date;
+        return $this->getIncludedEnd() < $date;
     }
 
     public function contains(DateTimeInterface $date): bool
     {
-        if ($date < $this->start) {
+        if ($date < $this->getIncludedStart()) {
             return false;
         }
 
-        if ($date > $this->end) {
+        if ($date > $this->getIncludedEnd()) {
             return false;
         }
 
@@ -228,11 +252,11 @@ class Period
 
     public function equals(Period $period): bool
     {
-        if ($period->start->getTimestamp() !== $this->start->getTimestamp()) {
+        if ($period->getIncludedStart()->getTimestamp() !== $this->getIncludedStart()->getTimestamp()) {
             return false;
         }
 
-        if ($period->end->getTimestamp() !== $this->end->getTimestamp()) {
+        if ($period->getIncludedEnd()->getTimestamp() !== $this->getIncludedEnd()->getTimestamp()) {
             return false;
         }
 
@@ -255,16 +279,16 @@ class Period
             return null;
         }
 
-        if ($this->start >= $period->end) {
+        if ($this->getIncludedStart() >= $period->getIncludedEnd()) {
             return static::make(
-                $period->end->add(new DateInterval('P1D')),
-                $this->start->sub(new DateInterval('P1D'))
+                $period->getIncludedEnd()->add($this->interval),
+                $this->getIncludedStart()->sub($this->interval)
             );
         }
 
         return static::make(
-            $this->end->add(new DateInterval('P1D')),
-            $period->start->sub(new DateInterval('P1D'))
+            $this->getIncludedEnd()->add($this->interval),
+            $period->getIncludedStart()->sub($this->interval)
         );
     }
 
@@ -275,13 +299,13 @@ class Period
      */
     public function overlapSingle(Period $period): ?Period
     {
-        $start = $this->start > $period->start
-            ? $this->start
-            : $period->start;
+        $start = $this->getIncludedStart() > $period->getIncludedStart()
+            ? $this->getIncludedStart()
+            : $period->getIncludedStart();
 
-        $end = $this->end < $period->end
-            ? $this->end
-            : $period->end;
+        $end = $this->getIncludedEnd() < $period->getIncludedEnd()
+            ? $this->getIncludedEnd()
+            : $period->getIncludedEnd();
 
         if ($start > $end) {
             return null;
@@ -345,24 +369,24 @@ class Period
 
         $overlap = $this->overlapSingle($period);
 
-        $start = $this->start < $period->start
-            ? $this->start
-            : $period->start;
+        $start = $this->getIncludedStart() < $period->getIncludedStart()
+            ? $this->getIncludedStart()
+            : $period->getIncludedStart();
 
-        $end = $this->end > $period->end
-            ? $this->end
-            : $period->end;
+        $end = $this->getIncludedEnd() > $period->getIncludedEnd()
+            ? $this->getIncludedEnd()
+            : $period->getIncludedEnd();
 
-        if ($overlap->start > $start) {
+        if ($overlap->getIncludedStart() > $start) {
             $periodCollection[] = static::make(
                 $start,
-                $overlap->start->sub(new DateInterval('P1D'))
+                $overlap->getIncludedStart()->sub($this->interval)
             );
         }
 
-        if ($overlap->end < $end) {
+        if ($overlap->getIncludedEnd() < $end) {
             $periodCollection[] = static::make(
-                $overlap->end->add(new DateInterval('P1D')),
+                $overlap->getIncludedEnd()->add($this->interval),
                 $end
             );
         }

--- a/src/Period.php
+++ b/src/Period.php
@@ -28,6 +28,12 @@ class Period
     /** @var int */
     private $exclusionMask;
 
+    /** @var \DateTimeImmutable */
+    private $includedStart;
+
+    /** @var \DateTimeImmutable */
+    private $includedEnd;
+
     public function __construct(
         DateTimeImmutable $start,
         DateTimeImmutable $end,
@@ -39,8 +45,16 @@ class Period
 
         $this->start = $start;
         $this->end = $end;
-        $this->interval = new DateInterval('P1D');
         $this->exclusionMask = $exclusionMask;
+        $this->interval = new DateInterval('P1D');
+
+        $this->includedStart = $this->startIncluded()
+            ? $this->start
+            : $this->start->add($this->interval);
+
+        $this->includedEnd = $this->endIncluded()
+            ? $this->end
+            : $this->end->sub($this->interval);
     }
 
     /**
@@ -143,11 +157,7 @@ class Period
 
     public function getIncludedStart(): DateTimeImmutable
     {
-        if ($this->startIncluded()) {
-            return $this->start;
-        }
-
-        return $this->start->add($this->interval);
+        return $this->includedStart;
     }
 
     public function getEnd(): DateTimeImmutable
@@ -157,11 +167,7 @@ class Period
 
     public function getIncludedEnd(): DateTimeImmutable
     {
-        if ($this->endIncluded()) {
-            return $this->end;
-        }
-
-        return $this->end->sub($this->interval);
+        return $this->includedEnd;
     }
 
     public function length(): int

--- a/src/Period.php
+++ b/src/Period.php
@@ -173,7 +173,7 @@ class Period
 
     public function endsAfterOrAt(DateTimeInterface $date): bool
     {
-        return $this->end >= $date;
+        return $this->getIncludedEnd() >= $date;
     }
 
     public function startsBeforeOrAt(DateTimeInterface $date): bool
@@ -183,7 +183,7 @@ class Period
 
     public function endsBeforeOrAt(DateTimeInterface $date): bool
     {
-        return $this->end <= $date;
+        return $this->getIncludedEnd() <= $date;
     }
 
     public function startsAfter(DateTimeInterface $date): bool
@@ -193,7 +193,7 @@ class Period
 
     public function endsAfter(DateTimeInterface $date): bool
     {
-        return $this->end > $date;
+        return $this->getIncludedEnd() > $date;
     }
 
     public function startsBefore(DateTimeInterface $date): bool

--- a/src/Period.php
+++ b/src/Period.php
@@ -476,7 +476,6 @@ class Period
     {
         [$year, $month, $day, $hour, $minute, $second] = explode(' ', $date->format('Y m d H i s'));
 
-        $year = (Precision::YEAR & $precision) === Precision::YEAR ? $year : '00';
         $month = (Precision::MONTH & $precision) === Precision::MONTH ? $month : '01';
         $day = (Precision::DAY & $precision) === Precision::DAY ? $day : '01';
         $hour = (Precision::HOUR & $precision) === Precision::HOUR ? $hour : '00';

--- a/src/Period.php
+++ b/src/Period.php
@@ -11,11 +11,6 @@ use Spatie\Period\Exceptions\InvalidPeriod;
 
 class Period
 {
-    const EXCLUDE_NONE = 0;
-    const EXCLUDE_START = 2;
-    const EXCLUDE_END = 4;
-    const EXCLUDE_ALL = 6;
-
     /** @var \DateTimeImmutable */
     protected $start;
 
@@ -92,7 +87,7 @@ class Period
 
     public function startExcluded(): bool
     {
-        return self::EXCLUDE_START & $this->exclusionMask;
+        return Boundaries::EXCLUDE_START & $this->exclusionMask;
     }
 
     public function endIncluded(): bool
@@ -102,7 +97,7 @@ class Period
 
     public function endExcluded(): bool
     {
-        return self::EXCLUDE_END & $this->exclusionMask;
+        return Boundaries::EXCLUDE_END & $this->exclusionMask;
     }
 
     protected static function resolveDate($date, ?string $format): DateTimeImmutable

--- a/src/Period.php
+++ b/src/Period.php
@@ -168,14 +168,9 @@ class Period
         return false;
     }
 
-    public function startsAfterOrAt(DateTimeInterface $date): bool
+    public function startsBefore(DateTimeInterface $date): bool
     {
-        return $this->getIncludedStart() >= $date;
-    }
-
-    public function endsAfterOrAt(DateTimeInterface $date): bool
-    {
-        return $this->getIncludedEnd() >= $date;
+        return $this->getIncludedStart() < $date;
     }
 
     public function startsBeforeOrAt(DateTimeInterface $date): bool
@@ -183,38 +178,71 @@ class Period
         return $this->getIncludedStart() <= $date;
     }
 
-    public function endsBeforeOrAt(DateTimeInterface $date): bool
-    {
-        return $this->getIncludedEnd() <= $date;
-    }
-
     public function startsAfter(DateTimeInterface $date): bool
     {
         return $this->getIncludedStart() > $date;
     }
 
-    public function endsAfter(DateTimeInterface $date): bool
+    public function startsAfterOrAt(DateTimeInterface $date): bool
     {
-        return $this->getIncludedEnd() > $date;
+        return $this->getIncludedStart() >= $date;
     }
 
-    public function startsBefore(DateTimeInterface $date): bool
+    public function startsAt(DateTimeInterface $date): bool
     {
-        return $this->getIncludedStart() < $date;
+        return $this->getIncludedStart()->getTimestamp() === $this->roundDate(
+            $date,
+            $this->precisionMask
+        )->getTimestamp();
     }
 
     public function endsBefore(DateTimeInterface $date): bool
     {
-        return $this->getIncludedEnd() < $date;
+        return $this->getIncludedEnd() < $this->roundDate(
+                $date,
+                $this->precisionMask
+            );
+    }
+
+    public function endsBeforeOrAt(DateTimeInterface $date): bool
+    {
+        return $this->getIncludedEnd() <= $this->roundDate(
+                $date,
+                $this->precisionMask
+            );
+    }
+
+    public function endsAfter(DateTimeInterface $date): bool
+    {
+        return $this->getIncludedEnd() > $this->roundDate(
+                $date,
+                $this->precisionMask
+            );
+    }
+
+    public function endsAfterOrAt(DateTimeInterface $date): bool
+    {
+        return $this->getIncludedEnd() >= $this->roundDate(
+                $date,
+                $this->precisionMask
+            );
+    }
+
+    public function endsAt(DateTimeInterface $date): bool
+    {
+        return $this->getIncludedEnd()->getTimestamp() === $this->roundDate(
+                $date,
+                $this->precisionMask
+            )->getTimestamp();
     }
 
     public function contains(DateTimeInterface $date): bool
     {
-        if ($date < $this->getIncludedStart()) {
+        if ($this->roundDate($date, $this->precisionMask) < $this->getIncludedStart()) {
             return false;
         }
 
-        if ($date > $this->getIncludedEnd()) {
+        if ($this->roundDate($date, $this->precisionMask) > $this->getIncludedEnd()) {
             return false;
         }
 
@@ -444,7 +472,7 @@ class Period
         return 'Y-m-d';
     }
 
-    protected function roundDate(DateTimeImmutable $date, int $precision): DateTimeImmutable
+    protected function roundDate(DateTimeInterface $date, int $precision): DateTimeImmutable
     {
         [$year, $month, $day, $hour, $minute, $second] = explode(' ', $date->format('Y m d H i s'));
 

--- a/src/PeriodCollection.php
+++ b/src/PeriodCollection.php
@@ -58,12 +58,12 @@ class PeriodCollection implements ArrayAccess, Iterator, Countable
         $end = null;
 
         foreach ($this as $period) {
-            if ($start === null || $start > $period->getStart()) {
-                $start = $period->getStart();
+            if ($start === null || $start > $period->getIncludedStart()) {
+                $start = $period->getIncludedStart();
             }
 
-            if ($end === null || $end < $period->getEnd()) {
-                $end = $period->getEnd();
+            if ($end === null || $end < $period->getIncludedEnd()) {
+                $end = $period->getIncludedEnd();
             }
         }
 

--- a/src/PeriodCollection.php
+++ b/src/PeriodCollection.php
@@ -59,11 +59,11 @@ class PeriodCollection implements ArrayAccess, Iterator, Countable
 
         foreach ($this as $period) {
             if ($start === null || $start > $period->getIncludedStart()) {
-                $start = $period->getIncludedStart();
+                $start = $period->getStart();
             }
 
             if ($end === null || $end < $period->getIncludedEnd()) {
-                $end = $period->getIncludedEnd();
+                $end = $period->getEnd();
             }
         }
 
@@ -71,7 +71,7 @@ class PeriodCollection implements ArrayAccess, Iterator, Countable
             return null;
         }
 
-        return new Period($start, $end);
+        return new Period($start, $end, Boundaries::EXCLUDE_NONE);
     }
 
     public function gaps(): PeriodCollection

--- a/src/PeriodCollection.php
+++ b/src/PeriodCollection.php
@@ -54,7 +54,6 @@ class PeriodCollection implements ArrayAccess, Iterator, Countable
     public function boundaries(): ?Period
     {
         $start = null;
-
         $end = null;
 
         foreach ($this as $period) {
@@ -71,7 +70,14 @@ class PeriodCollection implements ArrayAccess, Iterator, Countable
             return null;
         }
 
-        return new Period($start, $end, Boundaries::EXCLUDE_NONE);
+        [$firstPeriod] = $this->periods;
+
+        return new Period(
+            $start,
+            $end,
+            $firstPeriod->getPrecisionMask(),
+            Boundaries::EXCLUDE_NONE
+        );
     }
 
     public function gaps(): PeriodCollection

--- a/src/Precision.php
+++ b/src/Precision.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Period;
+
+interface Precision
+{
+    const YEAR = 32;
+    const MONTH = 48;
+    const DAY = 56;
+    const HOUR = 60;
+    const MINUTE = 62;
+    const SECOND = 63;
+}

--- a/tests/BoundaryTest.php
+++ b/tests/BoundaryTest.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Period\Tests;
 
-use Spatie\Period\Boundaries;
 use Spatie\Period\Period;
+use Spatie\Period\Boundaries;
 use PHPUnit\Framework\TestCase;
 
 class BoundaryTest extends TestCase

--- a/tests/BoundaryTest.php
+++ b/tests/BoundaryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\Period\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\Period\Period;
+
+class BoundaryTest extends TestCase
+{
+    /** @test */
+    public function exclude_none()
+    {
+        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_NONE);
+
+        $this->assertFalse($period->startExcluded());
+        $this->assertFalse($period->endExcluded());
+    }
+
+    /** @test */
+    public function exclude_start()
+    {
+        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_START);
+
+        $this->assertTrue($period->startExcluded());
+        $this->assertFalse($period->endExcluded());
+    }
+
+    /** @test */
+    public function exclude_end()
+    {
+        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_END);
+
+        $this->assertFalse($period->startExcluded());
+        $this->assertTrue($period->endExcluded());
+    }
+
+    /** @test */
+    public function exclude_all()
+    {
+        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_ALL);
+
+        $this->assertTrue($period->startExcluded());
+        $this->assertTrue($period->endExcluded());
+    }
+}

--- a/tests/BoundaryTest.php
+++ b/tests/BoundaryTest.php
@@ -57,7 +57,7 @@ class BoundaryTest extends TestCase
     }
 
     /** @test */
-    public function overlap_with_excluded_boundary()
+    public function overlap_with_excluded_boundaries()
     {
         $a = Period::make('2018-01-01', '2018-01-05', null, Period::EXCLUDE_END);
         $b = Period::make('2018-01-05', '2018-01-10');

--- a/tests/BoundaryTest.php
+++ b/tests/BoundaryTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Period\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Spatie\Period\Period;
 
 class BoundaryTest extends TestCase

--- a/tests/BoundaryTest.php
+++ b/tests/BoundaryTest.php
@@ -42,4 +42,33 @@ class BoundaryTest extends TestCase
         $this->assertTrue($period->startExcluded());
         $this->assertTrue($period->endExcluded());
     }
+
+    /** @test */
+    public function length_with_boundaries()
+    {
+        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_START);
+        $this->assertEquals(30, $period->length());
+
+        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_END);
+        $this->assertEquals(30, $period->length());
+
+        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_ALL);
+        $this->assertEquals(29, $period->length());
+    }
+
+    /** @test */
+    public function overlap_with_excluded_boundary()
+    {
+        $a = Period::make('2018-01-01', '2018-01-05', null, Period::EXCLUDE_END);
+        $b = Period::make('2018-01-05', '2018-01-10');
+        $this->assertFalse($a->overlapsWith($b));
+
+        $a = Period::make('2018-01-01', '2018-01-05');
+        $b = Period::make('2018-01-05', '2018-01-10', null, Period::EXCLUDE_START);
+        $this->assertFalse($a->overlapsWith($b));
+
+        $a = Period::make('2018-01-01', '2018-01-05');
+        $b = Period::make('2018-01-05', '2018-01-10');
+        $this->assertTrue($a->overlapsWith($b));
+    }
 }

--- a/tests/BoundaryTest.php
+++ b/tests/BoundaryTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Period\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Spatie\Period\Period;
 
 class BoundaryTest extends TestCase

--- a/tests/BoundaryTest.php
+++ b/tests/BoundaryTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Period\Tests;
 
+use Spatie\Period\Boundaries;
 use Spatie\Period\Period;
 use PHPUnit\Framework\TestCase;
 
@@ -10,7 +11,7 @@ class BoundaryTest extends TestCase
     /** @test */
     public function exclude_none()
     {
-        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_NONE);
+        $period = Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_NONE);
 
         $this->assertFalse($period->startExcluded());
         $this->assertFalse($period->endExcluded());
@@ -19,7 +20,7 @@ class BoundaryTest extends TestCase
     /** @test */
     public function exclude_start()
     {
-        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_START);
+        $period = Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_START);
 
         $this->assertTrue($period->startExcluded());
         $this->assertFalse($period->endExcluded());
@@ -28,7 +29,7 @@ class BoundaryTest extends TestCase
     /** @test */
     public function exclude_end()
     {
-        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_END);
+        $period = Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_END);
 
         $this->assertFalse($period->startExcluded());
         $this->assertTrue($period->endExcluded());
@@ -37,7 +38,7 @@ class BoundaryTest extends TestCase
     /** @test */
     public function exclude_all()
     {
-        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_ALL);
+        $period = Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_ALL);
 
         $this->assertTrue($period->startExcluded());
         $this->assertTrue($period->endExcluded());
@@ -46,25 +47,25 @@ class BoundaryTest extends TestCase
     /** @test */
     public function length_with_boundaries()
     {
-        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_START);
+        $period = Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_START);
         $this->assertEquals(30, $period->length());
 
-        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_END);
+        $period = Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_END);
         $this->assertEquals(30, $period->length());
 
-        $period = Period::make('2018-01-01', '2018-01-31', null, Period::EXCLUDE_ALL);
+        $period = Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_ALL);
         $this->assertEquals(29, $period->length());
     }
 
     /** @test */
     public function overlap_with_excluded_boundaries()
     {
-        $a = Period::make('2018-01-01', '2018-01-05', null, Period::EXCLUDE_END);
+        $a = Period::make('2018-01-01', '2018-01-05', null, Boundaries::EXCLUDE_END);
         $b = Period::make('2018-01-05', '2018-01-10');
         $this->assertFalse($a->overlapsWith($b));
 
         $a = Period::make('2018-01-01', '2018-01-05');
-        $b = Period::make('2018-01-05', '2018-01-10', null, Period::EXCLUDE_START);
+        $b = Period::make('2018-01-05', '2018-01-10', null, Boundaries::EXCLUDE_START);
         $this->assertFalse($a->overlapsWith($b));
 
         $a = Period::make('2018-01-01', '2018-01-05');

--- a/tests/BoundaryTest.php
+++ b/tests/BoundaryTest.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Period\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Spatie\Period\Period;
+use PHPUnit\Framework\TestCase;
 
 class BoundaryTest extends TestCase
 {

--- a/tests/PeriodCollectionTest.php
+++ b/tests/PeriodCollectionTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Spatie\Tests\Period;
+namespace Spatie\Period\Tests;
 
 use DateTimeImmutable;
 use Spatie\Period\Period;
-use PHPUnit\Framework\TestCase;
 use Spatie\Period\PeriodCollection;
 
 class PeriodCollectionTest extends TestCase

--- a/tests/PeriodCollectionTest.php
+++ b/tests/PeriodCollectionTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\Period\Tests;
 
 use DateTimeImmutable;
-use PHPUnit\Framework\TestCase;
 use Spatie\Period\Period;
+use PHPUnit\Framework\TestCase;
 use Spatie\Period\PeriodCollection;
 
 class PeriodCollectionTest extends TestCase

--- a/tests/PeriodCollectionTest.php
+++ b/tests/PeriodCollectionTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Period\Tests;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
 use Spatie\Period\Period;
 use Spatie\Period\PeriodCollection;
 

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Spatie\Tests\Period;
+namespace Spatie\Period\Tests;
 
 use Carbon\Carbon;
 use DateTimeImmutable;
 use Spatie\Period\Period;
-use PHPUnit\Framework\TestCase;
 
 class PeriodTest extends TestCase
 {

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Period\Tests;
 
 use Carbon\Carbon;
 use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
 use Spatie\Period\Period;
 
 class PeriodTest extends TestCase

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -4,8 +4,8 @@ namespace Spatie\Period\Tests;
 
 use Carbon\Carbon;
 use DateTimeImmutable;
-use PHPUnit\Framework\TestCase;
 use Spatie\Period\Period;
+use PHPUnit\Framework\TestCase;
 
 class PeriodTest extends TestCase
 {

--- a/tests/PrecisionTest.php
+++ b/tests/PrecisionTest.php
@@ -58,4 +58,70 @@ class PrecisionTest extends TestCase
 
         $a->overlapsWith($b);
     }
+
+    /** @test */
+    public function precision_with_seconds()
+    {
+        $a = Period::make('2018-01-01 00:00:15', '2018-01-01 00:00:15', Precision::SECOND);
+        $b = Period::make('2018-01-01 00:00:15', '2018-01-01 00:00:15', Precision::SECOND);
+        $c = Period::make('2018-01-01 00:00:16', '2018-01-01 00:00:16', Precision::SECOND);
+
+        $this->assertTrue($a->overlapsWith($b));
+        $this->assertFalse($a->overlapsWith($c));
+    }
+
+    /** @test */
+    public function precision_with_minutes()
+    {
+        $a = Period::make('2018-01-01 00:15:00', '2018-01-01 00:15:00', Precision::MINUTE);
+        $b = Period::make('2018-01-01 00:15:00', '2018-01-01 00:15:00', Precision::MINUTE);
+        $c = Period::make('2018-01-01 00:16:00', '2018-01-01 00:16:00', Precision::MINUTE);
+
+        $this->assertTrue($a->overlapsWith($b));
+        $this->assertFalse($a->overlapsWith($c));
+    }
+
+    /** @test */
+    public function precision_with_hours()
+    {
+        $a = Period::make('2018-01-01 15:00:00', '2018-01-01 15:00:00', Precision::HOUR);
+        $b = Period::make('2018-01-01 15:00:00', '2018-01-01 15:00:00', Precision::HOUR);
+        $c = Period::make('2018-01-01 16:00:00', '2018-01-01 16:00:00', Precision::HOUR);
+
+        $this->assertTrue($a->overlapsWith($b));
+        $this->assertFalse($a->overlapsWith($c));
+    }
+
+    /** @test */
+    public function precision_with_days()
+    {
+        $a = Period::make('2018-01-01', '2018-01-01', Precision::DAY);
+        $b = Period::make('2018-01-01', '2018-01-01', Precision::DAY);
+        $c = Period::make('2018-01-02', '2018-01-02', Precision::DAY);
+
+        $this->assertTrue($a->overlapsWith($b));
+        $this->assertFalse($a->overlapsWith($c));
+    }
+
+    /** @test */
+    public function precision_with_months()
+    {
+        $a = Period::make('2018-01-01', '2018-01-01', Precision::MONTH);
+        $b = Period::make('2018-01-01', '2018-01-01', Precision::MONTH);
+        $c = Period::make('2018-02-01', '2018-02-01', Precision::MONTH);
+
+        $this->assertTrue($a->overlapsWith($b));
+        $this->assertFalse($a->overlapsWith($c));
+    }
+
+    /** @test */
+    public function precision_with_years()
+    {
+        $a = Period::make('2018-01-01', '2018-01-01', Precision::YEAR);
+        $b = Period::make('2018-01-01', '2018-01-01', Precision::YEAR);
+        $c = Period::make('2019-01-01', '2019-01-01', Precision::YEAR);
+
+        $this->assertTrue($a->overlapsWith($b));
+        $this->assertFalse($a->overlapsWith($c));
+    }
 }

--- a/tests/PrecisionTest.php
+++ b/tests/PrecisionTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Period\Tests;
 
 use DateTime;
+use DateTimeImmutable;
 use Spatie\Period\Period;
 use Spatie\Period\Precision;
 use PHPUnit\Framework\TestCase;
@@ -123,5 +124,66 @@ class PrecisionTest extends TestCase
 
         $this->assertTrue($a->overlapsWith($b));
         $this->assertFalse($a->overlapsWith($c));
+    }
+
+    /** @test */
+    public function precision_is_kept_when_comparing_with_the_ranges_start()
+    {
+        $a = Period::make('2018-01-01 11:11:11', '2018-01-31', Precision::DAY);
+
+        $boundaryDate = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2018-01-01 11:11:11');
+
+        $this->assertTrue($a->startsAt($boundaryDate));
+
+        $includedDate = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2018-01-02 00:00:00');
+
+        $this->assertTrue($a->startsBefore($includedDate));
+        $this->assertTrue($a->startsBeforeOrAt($includedDate));
+        $this->assertFalse($a->startsAfter($includedDate));
+        $this->assertFalse($a->startsAfterOrAt($includedDate));
+
+        $excludedDate = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2017-12-31 23:59:59');
+
+        $this->assertFalse($a->startsBefore($excludedDate));
+        $this->assertFalse($a->startsBeforeOrAt($excludedDate));
+        $this->assertTrue($a->startsAfter($excludedDate));
+        $this->assertTrue($a->startsAfterOrAt($excludedDate));
+    }
+
+    /** @test */
+    public function precision_is_kept_when_comparing_with_the_ranges_end()
+    {
+        $a = Period::make('2018-01-01', '2018-01-31', Precision::DAY);
+
+        $boundaryDate = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2018-01-31 23:59:59');
+
+        $this->assertTrue($a->endsAt($boundaryDate));
+
+        $includedDate = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2018-01-30 23:59:59');
+
+        $this->assertTrue($a->endsAfter($includedDate));
+        $this->assertTrue($a->endsAfterOrAt($includedDate));
+        $this->assertFalse($a->endsBefore($includedDate));
+        $this->assertFalse($a->endsBeforeOrAt($includedDate));
+
+        $excludedDate = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2018-02-01 00:00:00');
+
+        $this->assertTrue($a->endsBefore($excludedDate));
+        $this->assertTrue($a->endsBeforeOrAt($excludedDate));
+        $this->assertFalse($a->endsAfter($excludedDate));
+        $this->assertFalse($a->endsAfterOrAt($excludedDate));
+    }
+
+    /** @test */
+    public function precision_is_kept_when_testing_contains()
+    {
+        $a = Period::make('2018-01-01', '2018-01-31', Precision::DAY);
+
+        $this->assertTrue($a->contains(DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2018-01-01 00:00:00')));
+        $this->assertTrue($a->contains(DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2018-01-02 00:00:00')));
+        $this->assertTrue($a->contains(DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2018-01-31 23:59:59')));
+
+        $this->assertFalse($a->contains(DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2018-02-01 00:00:00')));
+        $this->assertFalse($a->contains(DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2017-12-21 23:59:59')));
     }
 }

--- a/tests/PrecisionTest.php
+++ b/tests/PrecisionTest.php
@@ -3,11 +3,10 @@
 namespace Spatie\Period\Tests;
 
 use DateTime;
-use PHPUnit\Framework\TestCase;
-use Spatie\Period\Boundaries;
-use Spatie\Period\Exceptions\CannotComparePeriods;
 use Spatie\Period\Period;
 use Spatie\Period\Precision;
+use PHPUnit\Framework\TestCase;
+use Spatie\Period\Exceptions\CannotComparePeriods;
 
 class PrecisionTest extends TestCase
 {

--- a/tests/PrecisionTest.php
+++ b/tests/PrecisionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Spatie\Period\Tests;
+
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use Spatie\Period\Boundaries;
+use Spatie\Period\Exceptions\CannotComparePeriods;
+use Spatie\Period\Period;
+use Spatie\Period\Precision;
+
+class PrecisionTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider roundingDates
+     */
+    public function dates_are_rounded_on_precision(
+        int $precision,
+        string $expectedStart,
+        string $expectedEnd
+    ) {
+        $period = Period::make(
+            '2018-02-05 11:11:11',
+            '2018-03-05 11:11:11',
+            null,
+            Boundaries::EXCLUDE_NONE,
+            $precision
+        );
+
+        $this->assertEquals(
+            DateTime::createFromFormat('Y-m-d H:i:s', $expectedStart),
+            $period->getStart()
+        );
+
+        $this->assertEquals(
+            DateTime::createFromFormat('Y-m-d H:i:s', $expectedEnd),
+            $period->getEnd()
+        );
+    }
+
+    public function roundingDates(): array
+    {
+        return [
+            [Precision::YEAR, '2018-01-01 00:00:00', '2018-01-01 00:00:00'],
+            [Precision::MONTH, '2018-02-01 00:00:00', '2018-03-01 00:00:00'],
+            [Precision::DAY, '2018-02-05 00:00:00', '2018-03-05 00:00:00'],
+            [Precision::HOUR, '2018-02-05 11:00:00', '2018-03-05 11:00:00'],
+            [Precision::MINUTE, '2018-02-05 11:11:00', '2018-03-05 11:11:00'],
+            [Precision::SECOND, '2018-02-05 11:11:11', '2018-03-05 11:11:11'],
+        ];
+    }
+
+    /** @test */
+    public function comparing_two_periods_with_different_precision_is_not_allowed()
+    {
+        $a = Period::make('2018-01-01', '2018-01-01', null, Boundaries::EXCLUDE_NONE, Precision::MONTH);
+        $b = Period::make('2018-01-01', '2018-01-01', null, Boundaries::EXCLUDE_NONE, Precision::DAY);
+
+        $this->expectException(CannotComparePeriods::class);
+
+        $a->overlapsWith($b);
+    }
+}

--- a/tests/PrecisionTest.php
+++ b/tests/PrecisionTest.php
@@ -23,8 +23,6 @@ class PrecisionTest extends TestCase
         $period = Period::make(
             '2018-02-05 11:11:11',
             '2018-03-05 11:11:11',
-            null,
-            Boundaries::EXCLUDE_NONE,
             $precision
         );
 
@@ -54,8 +52,8 @@ class PrecisionTest extends TestCase
     /** @test */
     public function comparing_two_periods_with_different_precision_is_not_allowed()
     {
-        $a = Period::make('2018-01-01', '2018-01-01', null, Boundaries::EXCLUDE_NONE, Precision::MONTH);
-        $b = Period::make('2018-01-01', '2018-01-01', null, Boundaries::EXCLUDE_NONE, Precision::DAY);
+        $a = Period::make('2018-01-01', '2018-01-01', Precision::MONTH);
+        $b = Period::make('2018-01-01', '2018-01-01', Precision::DAY);
 
         $this->expectException(CannotComparePeriods::class);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\Period\Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Spatie\Period\Tests;
-
-use PHPUnit\Framework\TestCase as BaseTestCase;
-
-abstract class TestCase extends BaseTestCase
-{
-}

--- a/tests/VisualizerTest.php
+++ b/tests/VisualizerTest.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Period\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Spatie\Period\Period;
-use Spatie\Period\PeriodCollection;
 use Spatie\Period\Visualizer;
+use PHPUnit\Framework\TestCase;
+use Spatie\Period\PeriodCollection;
 
 class VisualizerTest extends TestCase
 {

--- a/tests/VisualizerTest.php
+++ b/tests/VisualizerTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Period\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Spatie\Period\Period;
 use Spatie\Period\PeriodCollection;
 use Spatie\Period\Visualizer;

--- a/tests/VisualizerTest.php
+++ b/tests/VisualizerTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Spatie\Tests\Period;
+namespace Spatie\Period\Tests;
 
 use Spatie\Period\Period;
-use Spatie\Period\Visualizer;
-use PHPUnit\Framework\TestCase;
 use Spatie\Period\PeriodCollection;
+use Spatie\Period\Visualizer;
 
 class VisualizerTest extends TestCase
 {


### PR DESCRIPTION
Adding boundary support, based on what we discussed in #9.

You'll notice that the default behaviour is "both boundaries included". This might not be everyone's preferred default. I heard the arguments pro and con in #9, but am still convinced that all inclusive is the right default behaviour as long as you're comparing periods with the same accuracy.

We could always add sub classes of `Period` if desired, with other defaults.

I'll leave this PR open for a while, to see what people think.

For those interested, I wrote down why I think working with precision instead of excluding boundaries is the superior approach: https://stitcher.io/blog/comparing-dates