### PR TITLE
Make Period iterable

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -2,15 +2,17 @@
 
 namespace Spatie\Period;
 
-use DateTime;
 use DateInterval;
+use DatePeriod;
+use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use IteratorAggregate;
 use Spatie\Period\Exceptions\InvalidDate;
 use Spatie\Period\Exceptions\InvalidPeriod;
 use Spatie\Period\Exceptions\CannotComparePeriods;
 
-class Period
+class Period implements IteratorAggregate
 {
     /** @var \DateTimeImmutable */
     protected $start;
@@ -434,6 +436,15 @@ class Period
     public function getPrecisionMask(): int
     {
         return $this->precisionMask;
+    }
+
+    public function getIterator()
+    {
+        return new DatePeriod(
+            $this->getIncludedStart(),
+            $this->interval,
+            $this->getIncludedEnd()->add($this->interval)
+        );
     }
 
     protected static function resolveDate($date, ?string $format): DateTimeImmutable

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -515,6 +515,14 @@ class PeriodTest extends TestCase
         $this->assertSame($expectedCount, iterator_count($period));
     }
 
+    /** @test */
+    public function its_iterator_returns_immutable_dates()
+    {
+        $period = Period::make('2018-01-01', '2018-01-15');
+
+        $this->assertInstanceOf(DateTimeImmutable::class, current($period));
+    }
+
     public function expectedPeriodLengths()
     {
         return [

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -4,8 +4,10 @@ namespace Spatie\Period\Tests;
 
 use Carbon\Carbon;
 use DateTimeImmutable;
-use Spatie\Period\Period;
 use PHPUnit\Framework\TestCase;
+use Spatie\Period\Period;
+use Spatie\Period\Precision;
+use Spatie\Period\Boundaries;
 
 class PeriodTest extends TestCase
 {
@@ -502,5 +504,29 @@ class PeriodTest extends TestCase
         $diff = $a->diff($b);
 
         $this->assertCount(2, $diff);
+    }
+
+    /**
+     * @test
+     * @dataProvider expectedPeriodLengths
+     */
+    public function it_is_iterable(int $expectedCount, Period $period)
+    {
+        $this->assertSame($expectedCount, iterator_count($period));
+    }
+
+    public function expectedPeriodLengths()
+    {
+        return [
+            [1, Period::make('2018-01-01', '2018-01-01')],
+
+            [15, Period::make('2018-01-01', '2018-01-15')],
+            [14, Period::make('2018-01-01', '2018-01-15', null, Boundaries::EXCLUDE_START)],
+            [14, Period::make('2018-01-01', '2018-01-15', null, Boundaries::EXCLUDE_END)],
+            [13, Period::make('2018-01-01', '2018-01-15', null, Boundaries::EXCLUDE_ALL)],
+
+            [24, Period::make('2018-01-01 00:00:00', '2018-01-01 23:59:59', Precision::HOUR)],
+            [24, Period::make('2018-01-01 00:00:00', '2018-01-02 00:00:00', Precision::HOUR, Boundaries::EXCLUDE_END)],
+        ];
     }
 }


### PR DESCRIPTION
I'm using this PR to propose a new feature, and at the same time ask a question about the the road that you envision this library (which I, by the way, like a lot ❤️) to go forward, because it is related to further contributions that I have in the pipeline as follow ups ^^

I am using Period in a project with the aim to replace the `DatePeriod` class where possible. To be able to do this, I'm missing the ability to iterate over a a Spatie period as I would with the native class.

That's why I would like make a Period iterable with the changes proposed in this PR, so that this would be possible:

```php
<?php

require 'vendor/autoload.php';

use Spatie\Period\Period;

$period = Period::make('2018-01-24', '2018-01-31');

foreach ($period as $date) {
    echo $date->format('Y-m-d').PHP_EOL;
}
```

That's where my question comes into play: I'm using `iterator_count()` to test if the Iterator iterates over the expected amount of dates, and noticed the `length()` method, of which I first thought that it does the same. However, `length()` always returns the amount of days in a Period, which was not was I expected.

Considering the following hour-based period (a Period with hour-precision) which I am also covering in the tests) I would have expected `length()` to return 24 instead of one.

```php
<?php

require 'vendor/autoload.php';

use Spatie\Period\Period;
use Spatie\Period\Precision;

$period = Period::make('2018-01-24 00:00:00', '2018-01-24 23:59:59', Precision::HOUR);

echo iterator_count($period).' vs '.$period->length(); // -> 24 vs 1
```

That's why I didn't change the `length()` method to return the iterator count, because this would be a breaking change, but I would like to use the opportunity for this question:

Is Spatie's Period supposed to support Date periods exclusively, or is the vision to make it a replacement for/extension of the native `DatePeriod` similarly as Carbon and Chronos are for `DateTime` and `DateTimeImmutable`?

:octocat: 

PS: I'm not sure why StyleCI wants me to do reorder the use statements as it suggests. I thought ordered imports where the way to go 😅 