### PR TITLE
Let length() use the Period's precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `period` will be documented in this file
 
+## 2.0.0
+
+- Breaking Change: `Period::length()` now uses the Period's precision instead of always returning days
+
 ## 1.1.1 - 2019-02-01
 
 - Fix bug with null element in diff

--- a/src/Period.php
+++ b/src/Period.php
@@ -135,9 +135,7 @@ class Period implements IteratorAggregate
 
     public function length(): int
     {
-        $length = $this->getIncludedStart()->diff($this->getIncludedEnd())->days + 1;
-
-        return $length;
+        return iterator_count($this);
     }
 
     public function overlapsWith(Period $period): bool

--- a/tests/BoundaryTest.php
+++ b/tests/BoundaryTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Period\Tests;
 
 use Spatie\Period\Period;
+use Spatie\Period\Precision;
 use Spatie\Period\Boundaries;
 use PHPUnit\Framework\TestCase;
 
@@ -44,17 +45,26 @@ class BoundaryTest extends TestCase
         $this->assertTrue($period->endExcluded());
     }
 
-    /** @test */
-    public function length_with_boundaries()
+    /**
+     * @test
+     * @dataProvider periodsWithAmountsOfIncludedDates
+     */
+    public function length_with_boundaries($expectedAmount, Period $period)
     {
-        $period = Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_START);
-        $this->assertEquals(30, $period->length());
+        $this->assertEquals($expectedAmount, $period->length());
+    }
 
-        $period = Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_END);
-        $this->assertEquals(30, $period->length());
+    public function periodsWithAmountsOfIncludedDates()
+    {
+        return [
+            [30, Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_START)],
+            [30, Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_END)],
+            [29, Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_ALL)],
 
-        $period = Period::make('2018-01-01', '2018-01-31', null, Boundaries::EXCLUDE_ALL);
-        $this->assertEquals(29, $period->length());
+            [23, Period::make('2018-01-01 00:00:00', '2018-01-01 23:59:00', Precision::HOUR, Boundaries::EXCLUDE_START)],
+            [23, Period::make('2018-01-01 00:00:00', '2018-01-01 23:59:00', Precision::HOUR, Boundaries::EXCLUDE_END)],
+            [22, Period::make('2018-01-01 00:00:00', '2018-01-01 23:59:00', Precision::HOUR, Boundaries::EXCLUDE_ALL)],
+        ];
     }
 
     /** @test */


### PR DESCRIPTION
`length()` now uses the Period's precision.

:octocat: 

---

Original PR text for Reference:

This adds a new method `amountOfIncludedDates()` and deprecates the method `length()` which currently doesn't account for a given precision.

I'm not a 100% sure about the name of the method, but `length()` seemed too ambiguous to me, so

> "How long is this period?" -> "It's 24 long"

would become

> "How many dates are included in my Period, based on the precision?" -> "There are 24"

Just deprecating the `length()` method would allow us to release a non-breaking 1.2 instead of a breaking 2.x. - when developers update the library through `composer update` and haven't disabled deprecation warnings in their dev/test environments, they will receive the information about the deprecated method and can change their code accordingly to be able to upgrade to the next major release with ease 🎉.

If they have enabled deprecation warnings in live environments… well, then this deprecation warning will teach them not to do that 😅

:octocat: 