### PR TITLE
Add Duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to `period` will be documented in this file
 `\Spatie\Period\PeriodCollection::overlap` should be used.
 - Breaking Change: `Period::length()` now uses the Period's precision instead of always returning days
 - Fix bug with `overlapAll` when no overlap
+- `Period::duration()` returns an instance of `Duration`
+- `PeriodCollection::duration()` returns an instance of `Duration` 
+  with the sum of all included Period's durations
 
 ## 1.4.1 - 2019-04-23
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ $period = Period::make(
 
 ```php
 $period->length(): int
+$period->duration(): Duration
+$period->duration()->length(Precision::*): int
 ```
 
 ```php
@@ -130,6 +132,16 @@ $periodCollection->gaps(): PeriodCollection
 ```
 
 ### Comparing periods
+
+**Period durations**
+```php
+$a = Period::make('2018-01-01', '2018-01-31');
+$b = Period::make('2018-02-01', '2018-02-28');
+
+$a->duration()->equals($b->duration()); // false
+$a->duration()->isLargerThan($b->duration()); // true
+$b->duration()->isSmallerThan($a->duration()); // true
+```
 
 **Overlaps with any other period**: 
 this method returns a `PeriodCollection` multiple `Period` objects representing the overlaps.

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\Period;
+
+use DateInterval;
+use DateTimeImmutable;
+
+final class Duration
+{
+    /** @var int */
+    private $seconds;
+
+    /** @var int */
+    private $precision;
+
+    private function __construct()
+    {
+    }
+
+    public static function make($value): self
+    {
+        if ($value instanceof Period) {
+            return self::fromPeriod($value);
+        }
+
+        if ($value instanceof PeriodCollection) {
+            return self::fromPeriodCollection($value);
+        }
+
+        if ($value instanceof DateInterval) {
+            return self::fromDateInterval($value);
+        }
+
+        $stringValue = (string) $value;
+
+        if (0 === strpos($stringValue, 'P')) {
+            return self::fromDateInterval(new DateInterval($stringValue));
+        }
+
+        return self::fromDateInterval(DateInterval::createFromDateString($stringValue));
+    }
+
+    public static function fromPeriod(Period $period): self
+    {
+        $start = $period->getIncludedStart();
+        $end = $period->getIncludedEnd();
+        $precision = $period->getPrecisionMask();
+
+        if ($precision === Precision::SECOND) {
+            $end = $end->add(new DateInterval('PT1S'));
+        } elseif ($precision === Precision::MINUTE) {
+            $end = $end->add(new DateInterval('PT1M'));
+        } elseif ($precision === Precision::HOUR) {
+            $end = $end->add(new DateInterval('PT1H'));
+        } elseif ($precision === Precision::DAY) {
+            $end = $end->add(new DateInterval('PT24H'));
+        } else {
+            throw new \InvalidArgumentException('A duration can only be determined up to a precision of Precision::DAY');
+        }
+
+        $duration = new self();
+        $duration->seconds = $end->getTimestamp() - $start->getTimestamp();
+        $duration->precision = $precision;
+
+        return $duration;
+    }
+
+    public static function fromPeriodCollection(PeriodCollection $collection): self
+    {
+        $duration = self::none();
+
+        foreach ($collection as $period) {
+            $duration = $duration->withAdded($period->duration());
+        }
+
+        return $duration;
+    }
+
+    public static function fromDateInterval(DateInterval $interval): self
+    {
+        $now = new DateTimeImmutable();
+        $then = $now->add($interval);
+
+        $duration = new self();
+        $duration->seconds = $then->getTimestamp() - $now->getTimestamp();
+        $duration->precision = self::determinePrecisionFromSeconds($duration->seconds);
+
+        return $duration;
+    }
+
+    public static function none(): self
+    {
+        $new = new self();
+        $new->seconds = 0;
+        $new->precision = Precision::SECOND;
+
+        return $new;
+    }
+
+    public function length(int $precision): int
+    {
+        switch ($precision) {
+            case Precision::SECOND:
+                return $this->seconds;
+            case Precision::MINUTE:
+                return intdiv($this->seconds, 60);
+            case Precision::HOUR:
+                return intdiv($this->seconds, 3600);
+            case Precision::DAY:
+                return intdiv($this->seconds, 86400);
+            default:
+                throw new \InvalidArgumentException('Unsupported precision for durations');
+        }
+    }
+
+    public function precision(): int
+    {
+        return $this->precision;
+    }
+
+    public function withAdded(self $other): self
+    {
+        $new = clone $this;
+        $new->seconds = $this->seconds + $other->length(Precision::SECOND);
+        $new->precision = $this->largestCommonPrecision($other);
+
+        return $new;
+    }
+
+    public function compareTo(self $other): int
+    {
+        $precision = $this->largestCommonPrecision($other);
+
+        return $this->length($precision) <=> $other->length($precision);
+    }
+
+    public function isLargerThan(self $other): bool
+    {
+        return 1 === $this->compareTo($other);
+    }
+
+    public function equals(self $other): bool
+    {
+        return 0 === $this->compareTo($other);
+    }
+
+    public function isSmallerThan(self $other): bool
+    {
+        return -1 === $this->compareTo($other);
+    }
+
+    private function largestCommonPrecision(self $other): int
+    {
+        return $this->precision >= $other->precision() ? $this->precision : $other->precision();
+    }
+
+    private static function determinePrecisionFromSeconds(int $seconds): int
+    {
+        $minutes = intdiv($seconds, 60);
+        $remainingSeconds = $seconds % 60;
+
+        if ($remainingSeconds !== 0) {
+            return Precision::SECOND;
+        }
+
+        $hours = intdiv($minutes, 60);
+        $remainingMinutes = $minutes % 60;
+
+        if ($remainingMinutes !== 0) {
+            return Precision::MINUTE;
+        }
+
+        // $days = intdiv($hours, 24);
+        $remainingHours = $hours % 24;
+
+        if ($remainingHours !== 0) {
+            return Precision::HOUR;
+        }
+
+        // Months and years are variable:
+        // A month could have 28 to 31 days
+        // A year can have 365 or 366 days (leap years)
+        return Precision::DAY;
+    }
+}

--- a/src/Period.php
+++ b/src/Period.php
@@ -453,6 +453,11 @@ class Period implements IteratorAggregate
         );
     }
 
+    public function duration(): Duration
+    {
+        return Duration::fromPeriod($this);
+    }
+
     protected static function resolveDate($date, ?string $format): DateTimeImmutable
     {
         if ($date instanceof DateTimeImmutable) {

--- a/src/PeriodCollection.php
+++ b/src/PeriodCollection.php
@@ -180,4 +180,9 @@ class PeriodCollection implements ArrayAccess, Iterator, Countable
 
         return $overlaps;
     }
+
+    public function duration(): Duration
+    {
+        return Duration::fromPeriodCollection($this);
+    }
 }

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\Period\Tests;
+
+use DateInterval;
+use Spatie\Period\Period;
+use Spatie\Period\Duration;
+use Spatie\Period\Precision;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Spatie\Period\PeriodCollection;
+
+class DurationTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider validDurations
+     */
+    public function it_can_be_made($expectedLength, $expectedPrecision, $value)
+    {
+        $duration = Duration::make($value);
+
+        $this->assertSame($expectedLength, $duration->length($expectedPrecision));
+    }
+
+    public function validDurations()
+    {
+        $weekPeriod = Period::make('2018-01-01', '2018-01-07');
+        $weekAsCollection = new PeriodCollection(
+            Period::make('2018-01-01', '2018-01-02'),
+            Period::make('2018-01-03', '2018-01-04'),
+            Period::make('2018-01-05', '2018-01-07')
+        );
+
+        return [
+            [7, Precision::DAY, '1 week'],
+            [7, Precision::DAY, 'P7D'],
+            [7, Precision::DAY, new DateInterval('P1W')],
+
+            [7, Precision::DAY, $weekPeriod],
+            [7 * 24, Precision::HOUR, $weekPeriod],
+            [7 * 24 * 60, Precision::MINUTE, $weekPeriod],
+            [7 * 24 * 60 * 60, Precision::SECOND, $weekPeriod],
+
+            [7, Precision::DAY, $weekAsCollection],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider periodsWithPrecisions
+     */
+    public function it_uses_the_precision_of_a_given_period($expectedPrecision, Period $period)
+    {
+        $duration = Duration::fromPeriod($period);
+        $this->assertSame($expectedPrecision, $duration->precision());
+    }
+
+    public function periodsWithPrecisions()
+    {
+        return [
+            [Precision::SECOND, Period::make('2018-01-01', '2018-01-02', Precision::SECOND)],
+            [Precision::MINUTE, Period::make('2018-01-01', '2018-01-02', Precision::MINUTE)],
+            [Precision::HOUR, Period::make('2018-01-01', '2018-01-02', Precision::HOUR)],
+            [Precision::DAY, Period::make('2018-01-01', '2018-01-02', Precision::DAY)],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider durationsWithPrecisions
+     */
+    public function it_can_determine_a_precision($expectedPrecision, $value)
+    {
+        $this->assertSame($expectedPrecision, Duration::make($value)->precision());
+    }
+
+    public function durationsWithPrecisions()
+    {
+        return [
+            [Precision::SECOND, '61 seconds'],
+            [Precision::MINUTE, '61 minutes'],
+            [Precision::HOUR, '25 hours'],
+            [Precision::DAY, '1 week'],
+            [Precision::DAY, '1 month'],
+            [Precision::DAY, '1 year'],
+        ];
+    }
+
+    /** @test */
+    public function it_can_be_compared()
+    {
+        $oneMinute = Duration::make('1 minute');
+        $sixtySeconds = Duration::make('60 seconds');
+        $none = Duration::none();
+
+        $this->assertTrue($oneMinute->equals($sixtySeconds));
+        $this->assertTrue($none->isSmallerThan($oneMinute));
+        $this->assertTrue($oneMinute->isLargerThan($none));
+    }
+
+    /**
+     * @test
+     * @dataProvider unsupportedPrecisions
+     */
+    public function it_does_not_support_precisions_with_variable_values(int $precision)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Duration::fromPeriod(Period::make('2018-01-01', '2018-01-31', $precision));
+    }
+
+    /**
+     * @test
+     * @dataProvider unsupportedPrecisions
+     */
+    public function its_length_can_not_be_retrieved_with_an_unsupported_precision(int $precision)
+    {
+        $duration = Duration::make('1337 seconds'); // doesn't matter
+
+        $this->expectException(InvalidArgumentException::class);
+        $duration->length($precision);
+    }
+
+    public function unsupportedPrecisions()
+    {
+        return [
+            [Precision::MONTH],
+            [Precision::YEAR],
+        ];
+    }
+}

--- a/tests/PeriodCollectionTest.php
+++ b/tests/PeriodCollectionTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Period\Tests;
 
 use DateTimeImmutable;
 use Spatie\Period\Period;
+use Spatie\Period\Duration;
 use PHPUnit\Framework\TestCase;
 use Spatie\Period\PeriodCollection;
 
@@ -203,5 +204,22 @@ class PeriodCollectionTest extends TestCase
         }, 0);
 
         $this->assertEquals(4, $totalLength);
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_duration()
+    {
+        $collection = new PeriodCollection(
+            Period::make('2018-01-01', '2018-01-05'),
+            Period::make('2018-01-11', '2018-01-15'),
+            Period::make('2018-01-21', '2018-01-25')
+        );
+
+        $duration = $collection->duration();
+        $expected = Duration::make('15 days');
+
+        $this->assertTrue($expected->equals($duration));
     }
 }

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -569,4 +569,12 @@ class PeriodTest extends TestCase
             [24, Period::make('2018-01-01 00:00:00', '2018-01-02 00:00:00', Precision::HOUR, Boundaries::EXCLUDE_END)],
         ];
     }
+
+    /** @test **/
+    public function it_has_a_duration()
+    {
+        $period = Period::make('2018-01-01', '2018-01-10');
+
+        $this->assertSame(10, $period->duration()->length(Precision::DAY));
+    }
 }


### PR DESCRIPTION
Another attempt to add a Duration object that can be used together with a Period.

Addresses #18, #22, #25 

### Added components/behaviour

- `Duration` class
- `Period::duration()` returns the duration of a period
- `PeriodCollection::duration()` returns the total duration of all periods included in the collection
- A duration takes the precision of a given Period. If a PeriodCollection is given, it uses the largest precision available in the collection
- When comparing durations, comparisons take please with the largest common precision
- The value of a duration can be retrieved with `Duration::length(Precision::*)`

I hope the `DurationTest` class is an adequate show case for what's possible (a.k.a. I'm too lazy to copy paste code examples 😅)

### Caveats

I don't think there is a way to reliably support variable precisions. To cite what I wrote in https://github.com/spatie/period/issues/18#issuecomment-458887498: 

> A duration (and for that matter a DateInterval) is a relative value, while a Period is based on absolute days. That causes problems when comparing periods like `(2018-03-01, 2018-03-31)` and `(2018-04-01, 2018-04-30)`. When representing both periods as Duration/DateInterval, the value would be `P1M` (= 1 month). So while these two are equal in terms of being a full month, they are not in terms of the number of included days. Similar problem with weeks/days in a week.

That's why (at the moment) I let `Duration` throw an InvalidArgumentException when a value with a precision larger than `Precision::DAY` is provided. I hope I'm wrong, so please correct me :)

:octocat: 