### PR TITLE
Add PeriodDuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `period` will be documented in this file
 `\Spatie\Period\PeriodCollection::overlap` should be used.
 - Breaking Change: `Period::length()` now uses the Period's precision instead of always returning days
 - Fix bug with `overlapAll` when no overlap
+- `\Spatie\Period\Period::duration()` returns an instance of `\Spatie\Period\PeriodDuration`
 
 ## 1.4.1 - 2019-04-23
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ $period = Period::make(
 
 ```php
 $period->length(): int
+$period->duration(): PeriodDuration
 ```
 
 ```php
@@ -97,6 +98,12 @@ $period->endsBefore(DateTimeInterface $date): bool
 $period->endsBeforeOrAt(DateTimeInterface $date): bool
 $period->endsAfter(DateTimeInterface $date): bool
 $period->endsAfterOrAt(DateTimeInterface $date): bool
+```
+
+```php
+$period->duration()->equals(PeriodDuration $other): bool
+$period->duration()->isLargerThan(PeriodDuration $other): bool
+$period->duration()->isSmallerThan(PeriodDuration $other): bool 
 ```
 
 ```php
@@ -236,6 +243,28 @@ $a = Period::make('2018-01-01', '2018-01-31');
 $b = Period::make('2018-02-05', '2018-02-15');
 
 $overlap = $a->gap($b); // Period('2018-02-01', '2018-02-04')
+```
+
+**Duration**: returns the duration of a period to compare it to other durations
+
+```php
+$january = Period::make('2018-01-01', '2018-01-31', Precision::MONTH);
+$february = Period::make('2018-02-01', '2018-02-28', Precision::MONTH);
+
+// both represent a month
+$january->duration()->equals($february->duration()); // true
+
+$march = Period::make('2018-03-01', '2018-03-31', Precision::DAY);
+$may = Period::make('2018-05-01', '2018-05-31', Precision::DAY);
+
+// both have 31 days
+$march->duration()->equals($may->duration()); // true
+
+$twoDays = Period::make('2018-01-01', '2018-01-02', Precision::DAY);
+$threeDays = Period::make('2018-01-01', '2018-01-03', Precision::DAY);
+
+$twoDays->duration()->isSmallerThan($threeDays->duration()); // true
+$threeDays->duration()->isLargerThan($twoDays->duration()); // true
 ```
 
 **Boundaries of a collection**: get one period representing the boundaries of a collection.

--- a/src/Period.php
+++ b/src/Period.php
@@ -35,6 +35,9 @@ class Period implements IteratorAggregate
     /** @var int */
     private $precisionMask;
 
+    /** @var PeriodDuration */
+    private $duration;
+
     public function __construct(
         DateTimeImmutable $start,
         DateTimeImmutable $end,
@@ -59,6 +62,8 @@ class Period implements IteratorAggregate
         $this->includedEnd = $this->endIncluded()
             ? $this->end
             : $this->end->sub($this->interval);
+
+        $this->duration = new PeriodDuration($this);
     }
 
     /**
@@ -136,6 +141,11 @@ class Period implements IteratorAggregate
     public function length(): int
     {
         return iterator_count($this);
+    }
+
+    public function duration(): PeriodDuration
+    {
+        return $this->duration;
     }
 
     public function overlapsWith(Period $period): bool

--- a/src/PeriodDuration.php
+++ b/src/PeriodDuration.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\Period;
+
+use DateTimeImmutable;
+
+final class PeriodDuration
+{
+    /** @var Period */
+    private $period;
+
+    public function __construct(Period $period)
+    {
+        $this->period = $period;
+    }
+
+    public function equals(PeriodDuration $other): bool
+    {
+        return $this->startAndEndDatesAreTheSameAs($other)
+            || $this->includedStartAndEndDatesAreTheSameAs($other)
+            || $this->numberOfDaysIsTheSameAs($other)
+            || $this->compareTo($other) === 0;
+    }
+
+    public function isLargerThan(PeriodDuration $other): bool
+    {
+        return $this->compareTo($other) === 1;
+    }
+
+    public function isSmallerThan(PeriodDuration $other): bool
+    {
+        return $this->compareTo($other) === -1;
+    }
+
+    public function compareTo(PeriodDuration $other): int
+    {
+        $now = new DateTimeImmutable('@'.time()); // Ensure a TimeZone independent instance
+
+        $here = $this->period->getIncludedEnd()->diff($this->period->getIncludedStart(), true);
+        $there = $other->period->getIncludedEnd()->diff($other->period->getIncludedStart(), true);
+
+        return $now->add($here)->getTimestamp() <=> $now->add($there)->getTimestamp();
+    }
+
+    private function startAndEndDatesAreTheSameAs(PeriodDuration $other): bool
+    {
+        return $this->period->getStart() == $other->period->getStart()
+            && $this->period->getEnd() == $other->period->getEnd();
+    }
+
+    private function includedStartAndEndDatesAreTheSameAs(PeriodDuration $other): bool
+    {
+        return $this->period->getIncludedStart() == $other->period->getIncludedStart()
+            && $this->period->getIncludedEnd() == $other->period->getIncludedEnd();
+    }
+
+    private function numberOfDaysIsTheSameAs(PeriodDuration $other)
+    {
+        $here = $this->period->getIncludedEnd()->diff($this->period->getIncludedStart(), true);
+        $there = $other->period->getIncludedEnd()->diff($other->period->getIncludedStart(), true);
+
+        return $here->format('%a') === $there->format('%a');
+    }
+}

--- a/tests/PeriodDurationTest.php
+++ b/tests/PeriodDurationTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\Period\Tests;
+
+use Spatie\Period\Period;
+use Spatie\Period\Precision;
+use Spatie\Period\Boundaries;
+use PHPUnit\Framework\TestCase;
+use Spatie\Period\PeriodDuration;
+
+class PeriodDurationTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider sames
+     */
+    public function it_is_the_same_as(Period $a, Period $b)
+    {
+        $duration = new PeriodDuration($a);
+        $other = new PeriodDuration($b);
+
+        $this->assertTrue($duration->equals($other));
+        $this->assertFalse($duration->isLargerThan($other));
+        $this->assertFalse($duration->isSmallerThan($other));
+        $this->assertSame(0, $duration->compareTo($other));
+    }
+
+    public function sames()
+    {
+        return [
+            [
+                Period::make('2019-04-01', '2019-04-02'),
+                Period::make('2019-04-01', '2019-04-02'),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider equals
+     */
+    public function it_is_equal_but_not_the_same(Period $a, Period $b)
+    {
+        $duration = new PeriodDuration($a);
+        $other = new PeriodDuration($b);
+
+        $this->assertTrue($duration->equals($other));
+        $this->assertFalse($duration->isLargerThan($other));
+        $this->assertFalse($duration->isSmallerThan($other));
+        $this->assertSame(0, $duration->compareTo($other));
+    }
+
+    public function equals()
+    {
+        return [
+            '1 year' => [ // P1Y, but P365T vs P366T (2020 is a leap year)
+                Period::make('2019-01-01', '2019-12-31', Precision::YEAR),
+                Period::make('2020-01-01', '2020-12-31', Precision::YEAR),
+            ],
+            '1 month' => [ // P1M , but P30D vs P28D
+                Period::make('2019-04-01', '2019-04-30', Precision::MONTH),
+                Period::make('2019-02-01', '2019-02-28', Precision::MONTH),
+            ],
+            '1 day' => [ // P1D , but but different days
+                Period::make('2019-04-23', '2019-04-23', Precision::DAY),
+                Period::make('2019-04-24', '2019-04-24', Precision::DAY),
+            ],
+            '12 hours' => [ // PT12H, but on different halves of the day
+                Period::make('2019-04-23 00:00:00', '2019-04-23 11:59:00', Precision::HOUR),
+                Period::make('2019-04-23 12:00:00', '2019-04-23 23:59:00', Precision::HOUR),
+            ],
+            '30 minutes' => [ // PT30M, but on different halves of the hour
+                Period::make('2019-04-23 11:45:00', '2019-04-23 12:14:59', Precision::MINUTE),
+                Period::make('2019-04-23 12:15:00', '2019-04-23 12:44:59', Precision::MINUTE),
+            ],
+            '30 seconds' => [ // PT30S, but on different halves of the minute
+                Period::make('2019-04-23 11:59:45', '2019-04-23 12:00:14', Precision::SECOND),
+                Period::make('2019-04-23 12:00:15', '2019-04-23 12:00:44', Precision::SECOND),
+            ],
+            'same amount of days within a month' => [ // P4D == P4D
+                Period::make('2019-02-01', '2019-02-28', Precision::DAY),
+                Period::make('2019-04-01', '2019-04-28', Precision::DAY),
+            ],
+            'same amount of days spanning two months' => [ // P4D is still P4D
+                Period::make('2019-02-27', '2019-03-02', Precision::DAY),
+                Period::make('2019-03-30', '2019-04-02', Precision::DAY),
+            ],
+            'same period, different precision' => [ // in this case P1D == P24H
+                Period::make('2019-04-23', '2019-04-23', Precision::DAY),
+                Period::make('2019-04-23', '2019-04-23', Precision::HOUR),
+            ],
+            'different boundaries, but same amount of days, ' => [ // P1D == P1D
+                Period::make('2019-04-23', '2019-04-23', Precision::DAY, Boundaries::EXCLUDE_NONE),
+                Period::make('2019-04-23', '2019-04-24', Precision::DAY, Boundaries::EXCLUDE_END),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider differents
+     */
+    public function it_is_different(Period $a, Period $b)
+    {
+        $duration = new PeriodDuration($a);
+        $other = new PeriodDuration($b);
+
+        $this->assertFalse($duration->equals($other));
+    }
+
+    public function differents()
+    {
+        return [
+            'a is smaller than b' => [
+                Period::make('2019-04-23', '2019-04-24', Precision::DAY),
+                Period::make('2019-04-23', '2019-04-25', Precision::DAY),
+            ],
+            'b is smaller than a' => [
+                Period::make('2019-04-23', '2019-04-25', Precision::DAY),
+                Period::make('2019-04-23', '2019-04-24', Precision::DAY),
+            ],
+        ];
+    }
+}

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -19,6 +19,15 @@ class PeriodTest extends TestCase
         $this->assertEquals(15, $period->length());
     }
 
+    /** @test */
+    public function it_has_a_duration()
+    {
+        $a = Period::make('2018-01-01', '2018-01-15');
+        $b = Period::make('2018-02-01', '2018-02-15');
+
+        $this->assertTrue($a->duration()->equals($b->duration()));
+    }
+
     /**
      * @test
      * @dataProvider overlappingDates


### PR DESCRIPTION
This is an alternative approach to #26 and tries to address the challenge that Period durations were only reliably usable with a precision up to `Precision::DAY`.

In #26, a `Duration` is a standalone Value Object, not connected to a Period it might have been created from, and its state is represented by the number of seconds that it is made of.

With #26, creating a duration from a Period would have resulted e.g. in the following values:

```php
$a = Period::make('2018-01-01', '2018-01-31', Precision::MONTH); // P1M
$b = Period::make('2018-02-01', '2018-02-28', Precision::MONTH); // P1M

$a->duration()->equals($b->duration()); // false, because the number of seconds doesn't match
```

A previous iteration of #26 used a `DateInterval`to represent the duration, but in that case, something like this wouldn't work:

```php
$a = Period::make('2018-01-01', '2018-01-31', Precision::MONTH); // P1M
$b = Period::make('2018-01-01', '2018-01-31', Precision::DAY); // P31D

$a->duration()->equals($b->duration()); // false, because the DateInterval is different
```

The advantage of #26 is that you can do `Duration::length(Precision $precision)` to get the actual value of the duration. This is not possible here, because here, different possibilities of "equality" can be considered, so that the following examples all return `true` when calling `$period->duration()->equals()` with each other.

```php
$a = Period::make('2018-01-01', '2018-01-31'); // P1M + P31D ?
$b = Period::make('2018-02-01', '2018-02-28'); // P1M + P28D ?
$c = Period::make('2020-03-01', '2020-03-28'); // P28D

// The following could be considered equal because ->getStart() and getEnd() return the same date
$d = Period::make('2018-01-01', '2018-01-31', Precision::DAY, Boundaries::EXCLUDE_ALL);
$e Period::make('2018-01-01', '2018-01-31', Precision::DAY, Boundaries::EXCLUDE_NONE);
```

I'm sure I missed edge cases, but I'm covering all that I could think of in the tests.

As this library is about comparisons, perhaps getting an actual value from the duration is not so important, perhaps I'm wrong and perhaps I'm just going crazy 😅 - for the past week, I've spent almost every evening trying to wrap my head around this in dozens of local branches and always found something that didn't work out - so this is my last attempt. If #26 or this one here doesn't make sense, it's perhaps not meant to be 😅 

:octocat: 