### PR TITLE
Allow a Period's precision to be changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.lock
 docs
 vendor
 coverage
+
+/phpunit.xml

--- a/src/Period.php
+++ b/src/Period.php
@@ -454,6 +454,46 @@ class Period implements IteratorAggregate
         return $this->precisionMask;
     }
 
+    public function withChangedPrecision(int $targetPrecision): Period
+    {
+        // Example
+        // (2019-04-01, 2019-04-31) Precision::DAY
+        $newStart = $this->includedStart;
+
+        // becomes (2019-04-01, 2019-05-01)
+        $newEnd = $this->includedEnd->add($this->interval);
+
+        switch ($targetPrecision) {
+            case Precision::SECOND:
+                // becomes (2019-04-01 00:00:00, 2019-04-30 23:59:59)
+                $newEnd = $newEnd->sub(new DateInterval('PT1S'));
+                break;
+            case Precision::MINUTE:
+                // becomes (2019-04-01 00:00:00, 2019-04-30 23:59:00)
+                $newEnd = $newEnd->sub(new DateInterval('PT1M'));
+                break;
+            case Precision::HOUR:
+                // becomes (2019-04-01 00:00:00, 2019-04-30 23:00:00)
+                $newEnd = $newEnd->sub(new DateInterval('PT1H'));
+                break;
+            case Precision::DAY:
+                // becomes (2019-04-01, 2019-04-30)
+                $newEnd = $newEnd->sub(new DateInterval('P1D'));
+                break;
+            case Precision::MONTH:
+                // becomes (2019-04-01, 2019-04-01)
+                $newEnd = $newEnd->sub(new DateInterval('P1M'));
+                break;
+        }
+
+        return new static(
+            $newStart,
+            $newEnd,
+            $targetPrecision,
+            Boundaries::EXCLUDE_NONE
+        );
+    }
+
     public function getIterator()
     {
         return new DatePeriod(

--- a/src/Period.php
+++ b/src/Period.php
@@ -456,34 +456,11 @@ class Period implements IteratorAggregate
 
     public function withChangedPrecision(int $targetPrecision): Period
     {
-        // Example
-        // (2019-04-01, 2019-04-31) Precision::DAY
         $newStart = $this->includedStart;
-
-        // becomes (2019-04-01, 2019-05-01)
         $newEnd = $this->includedEnd->add($this->interval);
 
-        switch ($targetPrecision) {
-            case Precision::SECOND:
-                // becomes (2019-04-01 00:00:00, 2019-04-30 23:59:59)
-                $newEnd = $newEnd->sub(new DateInterval('PT1S'));
-                break;
-            case Precision::MINUTE:
-                // becomes (2019-04-01 00:00:00, 2019-04-30 23:59:00)
-                $newEnd = $newEnd->sub(new DateInterval('PT1M'));
-                break;
-            case Precision::HOUR:
-                // becomes (2019-04-01 00:00:00, 2019-04-30 23:00:00)
-                $newEnd = $newEnd->sub(new DateInterval('PT1H'));
-                break;
-            case Precision::DAY:
-                // becomes (2019-04-01, 2019-04-30)
-                $newEnd = $newEnd->sub(new DateInterval('P1D'));
-                break;
-            case Precision::MONTH:
-                // becomes (2019-04-01, 2019-04-01)
-                $newEnd = $newEnd->sub(new DateInterval('P1M'));
-                break;
+        if ($targetPrecision !== Precision::YEAR) {
+            $newEnd = $newEnd->sub($this->createDateInterval($targetPrecision));
         }
 
         return new static(

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -583,7 +583,7 @@ class PeriodTest extends TestCase
      * @test
      * @dataProvider periodsWithChangedPrecisions
      */
-    public function its_precision_can_be_changed(int $expectedLength, int $targetPrecision, Period $period)
+    public function its_precision_can_be_changed(Period $period, int $targetPrecision, int $expectedLength)
     {
         $this->assertSame($expectedLength, $period->withChangedPrecision($targetPrecision)->length());
     }
@@ -592,79 +592,79 @@ class PeriodTest extends TestCase
     {
         return [
             '2 days in hours' => [
-                48,
-                Precision::HOUR,
                 Period::make('2019-04-01', '2019-04-02', Precision::DAY, Boundaries::EXCLUDE_NONE),
+                Precision::HOUR,
+                48,
             ],
             '1 day in hours' => [
-                24,
-                Precision::HOUR,
                 Period::make('2019-04-01', '2019-04-02', Precision::DAY, Boundaries::EXCLUDE_END),
+                Precision::HOUR,
+                24,
             ],
             '1 week in hours' => [
-                168,
-                Precision::HOUR,
                 Period::make('2019-04-01', '2019-04-07', Precision::DAY, Boundaries::EXCLUDE_NONE),
+                Precision::HOUR,
+                168,
             ],
             '30 days in april' => [
-                30,
-                Precision::DAY,
                 Period::make('2019-04-01', '2019-04-30', Precision::MONTH, Boundaries::EXCLUDE_NONE),
+                Precision::DAY,
+                30,
             ],
             '60 minutes in an hour' => [
-                60,
-                Precision::MINUTE,
                 Period::make('2019-04-01 00:00:00', '2019-04-01 01:00:00', Precision::HOUR, Boundaries::EXCLUDE_END),
+                Precision::MINUTE,
+                60,
             ],
             '60 seconds in a minute' => [
-                60,
-                Precision::SECOND,
                 Period::make('2019-04-01 00:00:00', '2019-04-01 00:01:00', Precision::MINUTE, Boundaries::EXCLUDE_END),
+                Precision::SECOND,
+                60,
             ],
             '60 minutes are 1 hour' => [
-                1,
-                Precision::HOUR,
                 Period::make('2019-04-01 00:00:00', '2019-04-01 01:00:00', Precision::HOUR, Boundaries::EXCLUDE_END),
+                Precision::HOUR,
+                1,
             ],
             'any amount of days in one month are 1 month' => [
-                1,
-                Precision::MONTH,
                 Period::make('2019-04-01', '2019-04-30', Precision::DAY, Boundaries::EXCLUDE_NONE),
+                Precision::MONTH,
+                1,
             ],
             'any amount of days spanning two months are 2 months' => [
-                2,
-                Precision::MONTH,
                 Period::make('2019-04-01', '2019-05-31', Precision::DAY, Boundaries::EXCLUDE_NONE),
+                Precision::MONTH,
+                2,
             ],
             'any amount of days in a year is a year' => [
-                1,
-                Precision::YEAR,
                 Period::make('2019-04-01', '2019-05-31', Precision::DAY, Boundaries::EXCLUDE_NONE),
+                Precision::YEAR,
+                1,
             ],
             'any amount of months in a year is a year' => [
-                1,
-                Precision::YEAR,
                 Period::make('2019-04-01', '2019-05-31', Precision::MONTH, Boundaries::EXCLUDE_NONE),
+                Precision::YEAR,
+                1,
             ],
             'any amount of hours in a year is a year' => [
-                1,
-                Precision::YEAR,
                 Period::make('2019-04-01', '2019-05-31', Precision::HOUR, Boundaries::EXCLUDE_NONE),
+                Precision::YEAR,
+                1,
             ],
             'any amount of hours spanning two years are two years' => [
-                2,
-                Precision::YEAR,
                 Period::make('2019-04-01', '2020-05-31', Precision::HOUR, Boundaries::EXCLUDE_NONE),
+                Precision::YEAR,
+                2,
             ],
             'any amount of days spanning two years are two years' => [
-                2,
-                Precision::YEAR,
                 Period::make('2019-04-01', '2020-05-31', Precision::DAY, Boundaries::EXCLUDE_NONE),
+                Precision::YEAR,
+                2,
             ],
             'any amount of months spanning two years are two years' => [
-                2,
-                Precision::YEAR,
                 Period::make('2019-04-01', '2020-05-31', Precision::MONTH, Boundaries::EXCLUDE_NONE),
+                Precision::YEAR,
+                2,
             ],
         ];
     }

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -578,4 +578,94 @@ class PeriodTest extends TestCase
             [24, Period::make('2018-01-01 00:00:00', '2018-01-02 00:00:00', Precision::HOUR, Boundaries::EXCLUDE_END)],
         ];
     }
+
+    /**
+     * @test
+     * @dataProvider periodsWithChangedPrecisions
+     */
+    public function its_precision_can_be_changed(int $expectedLength, int $targetPrecision, Period $period)
+    {
+        $this->assertSame($expectedLength, $period->withChangedPrecision($targetPrecision)->length());
+    }
+
+    public function periodsWithChangedPrecisions()
+    {
+        return [
+            '2 days in hours' => [
+                48,
+                Precision::HOUR,
+                Period::make('2019-04-01', '2019-04-02', Precision::DAY, Boundaries::EXCLUDE_NONE),
+            ],
+            '1 day in hours' => [
+                24,
+                Precision::HOUR,
+                Period::make('2019-04-01', '2019-04-02', Precision::DAY, Boundaries::EXCLUDE_END),
+            ],
+            '1 week in hours' => [
+                168,
+                Precision::HOUR,
+                Period::make('2019-04-01', '2019-04-07', Precision::DAY, Boundaries::EXCLUDE_NONE),
+            ],
+            '30 days in april' => [
+                30,
+                Precision::DAY,
+                Period::make('2019-04-01', '2019-04-30', Precision::MONTH, Boundaries::EXCLUDE_NONE),
+            ],
+            '60 minutes in an hour' => [
+                60,
+                Precision::MINUTE,
+                Period::make('2019-04-01 00:00:00', '2019-04-01 01:00:00', Precision::HOUR, Boundaries::EXCLUDE_END),
+            ],
+            '60 seconds in a minute' => [
+                60,
+                Precision::SECOND,
+                Period::make('2019-04-01 00:00:00', '2019-04-01 00:01:00', Precision::MINUTE, Boundaries::EXCLUDE_END),
+            ],
+            '60 minutes are 1 hour' => [
+                1,
+                Precision::HOUR,
+                Period::make('2019-04-01 00:00:00', '2019-04-01 01:00:00', Precision::HOUR, Boundaries::EXCLUDE_END),
+            ],
+            'any amount of days in one month are 1 month' => [
+                1,
+                Precision::MONTH,
+                Period::make('2019-04-01', '2019-04-30', Precision::DAY, Boundaries::EXCLUDE_NONE),
+            ],
+            'any amount of days spanning two months are 2 months' => [
+                2,
+                Precision::MONTH,
+                Period::make('2019-04-01', '2019-05-31', Precision::DAY, Boundaries::EXCLUDE_NONE),
+            ],
+            'any amount of days in a year is a year' => [
+                1,
+                Precision::YEAR,
+                Period::make('2019-04-01', '2019-05-31', Precision::DAY, Boundaries::EXCLUDE_NONE),
+            ],
+            'any amount of months in a year is a year' => [
+                1,
+                Precision::YEAR,
+                Period::make('2019-04-01', '2019-05-31', Precision::MONTH, Boundaries::EXCLUDE_NONE),
+            ],
+            'any amount of hours in a year is a year' => [
+                1,
+                Precision::YEAR,
+                Period::make('2019-04-01', '2019-05-31', Precision::HOUR, Boundaries::EXCLUDE_NONE),
+            ],
+            'any amount of hours spanning two years are two years' => [
+                2,
+                Precision::YEAR,
+                Period::make('2019-04-01', '2020-05-31', Precision::HOUR, Boundaries::EXCLUDE_NONE),
+            ],
+            'any amount of days spanning two years are two years' => [
+                2,
+                Precision::YEAR,
+                Period::make('2019-04-01', '2020-05-31', Precision::DAY, Boundaries::EXCLUDE_NONE),
+            ],
+            'any amount of months spanning two years are two years' => [
+                2,
+                Precision::YEAR,
+                Period::make('2019-04-01', '2020-05-31', Precision::MONTH, Boundaries::EXCLUDE_NONE),
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Closes #18

The original goal was to define a precision when retrieving the length of a period.

By changing the Period's precision before getting its length, we don't need to change the signature of the `length()` method.

:octocat: 

PS: This PR was created during `Period::make('2019-04-29 19:00:00', '2019-04-29 20:23:00', Precision::MINUTE)` in my first Twitch livestream, and I'm not capable of writing a better PR description right now 😅 