### PR TITLE
Allow extension of Period that forces extension of DateTimeImmutable

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -86,8 +86,8 @@ class Period implements IteratorAggregate
         }
 
         return new static(
-            self::resolveDate($start, $format),
-            self::resolveDate($end, $format),
+            static::resolveDate($start, $format),
+            static::resolveDate($end, $format),
             $precisionMask,
             $boundaryExclusionMask
         );
@@ -461,7 +461,7 @@ class Period implements IteratorAggregate
             return DateTimeImmutable::createFromMutable($date);
         }
 
-        $format = self::resolveFormat($date, $format);
+        $format = static::resolveFormat($date, $format);
 
         if (! is_string($date)) {
             throw InvalidDate::forFormat($date, $format);

--- a/tests/DateTimeExtensionTest.php
+++ b/tests/DateTimeExtensionTest.php
@@ -2,7 +2,10 @@
 
 namespace Spatie\Period\Tests;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
+use Spatie\Period\Period;
 
 class DateTimeExtensionTest extends TestCase
 {
@@ -32,11 +35,11 @@ class DateTimeExtensionTest extends TestCase
 /**
  * In real life this would be Carbon or Chronos.
  */
-class DateTimeExtension extends \DateTimeImmutable
+class DateTimeExtension extends DateTimeImmutable
 {
-    public static function instance(\DateTimeImmutable $dt): self
+    public static function instance(DateTimeImmutable $dateTime): self
     {
-        return new static($dt->format('Y-m-d H:i:s.u'), $dt->getTimezone());
+        return new static($dateTime->format('Y-m-d H:i:s.u'), $dateTime->getTimezone());
     }
 }
 
@@ -46,10 +49,11 @@ class DateTimeExtension extends \DateTimeImmutable
  * @method DateTimeExtension getEnd
  * @method DateTimeExtension getIncludedEnd
  */
-class TestPeriod extends \Spatie\Period\Period
+class TestPeriod extends Period
 {
     /** @var DateTimeExtension */
     protected $start;
+
     /** @var DateTimeExtension */
     protected $end;
 
@@ -59,13 +63,13 @@ class TestPeriod extends \Spatie\Period\Period
     }
 
     /** @return DateTimeExtension */
-    protected static function resolveDate($date, ?string $format): \DateTimeImmutable
+    protected static function resolveDate($date, ?string $format): DateTimeImmutable
     {
         return DateTimeExtension::instance(parent::resolveDate($date, $format));
     }
 
     /** @return DateTimeExtension */
-    protected function roundDate(\DateTimeInterface $date, int $precision): \DateTimeImmutable
+    protected function roundDate(DateTimeInterface $date, int $precision): DateTimeImmutable
     {
         return DateTimeExtension::instance(parent::roundDate($date, $precision));
     }

--- a/tests/DateTimeExtensionTest.php
+++ b/tests/DateTimeExtensionTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Spatie\Period\Tests;
 
@@ -30,7 +30,7 @@ class DateTimeExtensionTest extends TestCase
 }
 
 /**
- * In real life this would be Carbon or Chronos
+ * In real life this would be Carbon or Chronos.
  */
 class DateTimeExtension extends \DateTimeImmutable
 {

--- a/tests/DateTimeExtensionTest.php
+++ b/tests/DateTimeExtensionTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Spatie\Period\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class DateTimeExtensionTest extends TestCase
+{
+    /** @test */
+    public function it_should_be_possible_use_date_time_extensions() : void
+    {
+        $start = new DateTimeExtension('2019-05-22');
+        $end = new DateTimeExtension('2019-06-05');
+        $period = new TestPeriod($start, $end);
+
+        $this->assertInstanceOf(DateTimeExtension::class, $period->getStart());
+        $this->assertInstanceOf(DateTimeExtension::class, $period->getEnd());
+        $this->assertInstanceOf(DateTimeExtension::class, $period->getIncludedStart());
+        $this->assertInstanceOf(DateTimeExtension::class, $period->getIncludedEnd());
+    }
+
+    /** @test */
+    public function it_should_be_possible_to_use_period_extension_to_force_date_time_extension() : void
+    {
+        $period = TestPeriod::make('2019-05-01', '2019-05-31');
+
+        $this->assertInstanceOf(TestPeriod::class, $period);
+        $this->assertInstanceOf(DateTimeExtension::class, $period->getStart());
+    }
+}
+
+/**
+ * In real life this would be Carbon or Chronos
+ */
+class DateTimeExtension extends \DateTimeImmutable
+{
+    public static function instance(\DateTimeImmutable $dt): self
+    {
+        return new static($dt->format('Y-m-d H:i:s.u'), $dt->getTimezone());
+    }
+}
+
+/**
+ * @method DateTimeExtension getStart
+ * @method DateTimeExtension getIncludedStart
+ * @method DateTimeExtension getEnd
+ * @method DateTimeExtension getIncludedEnd
+ */
+class TestPeriod extends \Spatie\Period\Period
+{
+    /** @var DateTimeExtension */
+    protected $start;
+    /** @var DateTimeExtension */
+    protected $end;
+
+    public function __construct(DateTimeExtension $start, DateTimeExtension $end, ?int $precisionMask = null, ?int $boundaryExclusionMask = null)
+    {
+        parent::__construct($start, $end, $precisionMask, $boundaryExclusionMask);
+    }
+
+    /** @return DateTimeExtension */
+    protected static function resolveDate($date, ?string $format): \DateTimeImmutable
+    {
+        return DateTimeExtension::instance(parent::resolveDate($date, $format));
+    }
+
+    /** @return DateTimeExtension */
+    protected function roundDate(\DateTimeInterface $date, int $precision): \DateTimeImmutable
+    {
+        return DateTimeExtension::instance(parent::roundDate($date, $precision));
+    }
+}


### PR DESCRIPTION
Allow extension of Period that forces extension of DateTimeImmutable (like Carbon or Chronos)

With some annotations I could pretty simply extend Period to a version that only works with Chronos objects in my project. There was only one issue in Period where it forces its own class instead of the extended class.

The accompanying test looks pretty complex for such a small change, but it best explains the issue.