### PR TITLE
Add conversion from and to native DatePeriods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `period` will be documented in this file
 
+## Unreleased
+
+- Add `Period::fromDatePeriod(DatePeriod $period): Period`
+- Add `asDatePeriod(): DatePeriod` to `Period`
+
 ## 1.4.4 - 2019-08-05
 
 - ~Performance improvement in `Period::contains()` (#46)~ edit: this change wasn't merged and targeted at 2.0

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ $period = Period::make(
 )
 ```
 
+The static `::fromDatePeriod` constructor accepts `DatePeriod` objects:
+
+```php
+$period = Period::fromDatePeriod(DatePeriod $nativeDatePeriod)
+``` 
+
 #### Length and boundaries
 
 ```php


### PR DESCRIPTION
As proposed in the conversation around #44, this PR adds methods to create a `Period` from a native `DatePeriod` and vice versa.

The conversions are based on the assumption that if I create a `Period` with an exclusion parameter other than `Boundaries::EXCLUDE_NONE`, I'm not interested in the exclusion (otherwise, `Period::contains()` wouldn't return false).

```php
use Spatie\Period\Boundaries;
use Spatie\Period\Period;
use Spatie\Period\Precision;

$period = Period::make(
    '2018-01-01',
    '2018-01-07',
    Precision::DAY,
    Boundaries::EXCLUDE_START
);

assert($period->contains(new DateTime('2018-01-01')) === false);
```

---

Accordingly, converting a native `DatePeriod` to a `Period`, followed by a conversion from a `Period` to a native `DatePeriod` doesn't necessarily mean that the output is equal to the input:

```php
$nativeInputPeriod = new DatePeriod(
    new DateTime('2018-01-01'),
    new DateInterval('P1D'),
    new DateTime('2018-01-07'),
    DatePeriod::EXCLUDE_START_DATE
);

$period = Period::fromDatePeriod($nativeInputPeriod);

assert($period->contains(new DateTime('2018-01-01')) === false);

$nativeOutputPeriod = $period->asDatePeriod();

assert($nativeOutputPeriod->include_start_date === true);
assert($nativeOutputPeriod->getStartDate() == new DateTime('2018-01-02'));
```

This is targeting a 1.x release because it's only added functionality without breaking changes.

:octocat: 
