### PR TITLE
Support multiple precisions when checking touchesWith

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -159,12 +159,40 @@ class Period implements IteratorAggregate
     {
         $this->ensurePrecisionMatches($period);
 
-        if ($this->getIncludedEnd()->diff($period->getIncludedStart())->days <= 1) {
-            return true;
+        $diff = $this->getIncludedStart()->diff($period->getIncludedEnd());
+
+        if($this->endsBefore($period->getIncludedStart())){
+            $diff = $this->getIncludedEnd()->diff($period->getIncludedStart());
         }
 
-        if ($this->getIncludedStart()->diff($period->getIncludedEnd())->days <= 1) {
-            return true;
+        switch ($this->getPrecisionMask()) {
+            case Precision::YEAR:
+                return $diff->y <= 1;
+            case Precision::MONTH:
+                return $diff->m <= 1
+                    && $diff->y === 0;
+            case Precision::DAY:
+                return $diff->d <= 1
+                    && $diff->m === 0
+                    && $diff->y === 0;
+            case Precision::HOUR:
+                return $diff->h <= 1
+                    && $diff->d === 0
+                    && $diff->m === 0
+                    && $diff->y === 0;
+            case Precision::MINUTE:
+                return $diff->i <= 1
+                    && $diff->h === 0
+                    && $diff->d === 0
+                    && $diff->m === 0
+                    && $diff->y === 0;
+            case Precision::SECOND:
+                return $diff->s <= 1
+                    && $diff->i === 0
+                    && $diff->h === 0
+                    && $diff->d === 0
+                    && $diff->m === 0
+                    && $diff->y === 0;
         }
 
         return false;

--- a/src/Period.php
+++ b/src/Period.php
@@ -165,37 +165,24 @@ class Period implements IteratorAggregate
             $diff = $this->getIncludedEnd()->diff($period->getIncludedStart());
         }
 
-        switch ($this->getPrecisionMask()) {
-            case Precision::YEAR:
-                return $diff->y <= 1;
-            case Precision::MONTH:
-                return $diff->m <= 1
-                    && $diff->y === 0;
-            case Precision::DAY:
-                return $diff->d <= 1
-                    && $diff->m === 0
-                    && $diff->y === 0;
-            case Precision::HOUR:
-                return $diff->h <= 1
-                    && $diff->d === 0
-                    && $diff->m === 0
-                    && $diff->y === 0;
-            case Precision::MINUTE:
-                return $diff->i <= 1
-                    && $diff->h === 0
-                    && $diff->d === 0
-                    && $diff->m === 0
-                    && $diff->y === 0;
-            case Precision::SECOND:
-                return $diff->s <= 1
-                    && $diff->i === 0
-                    && $diff->h === 0
-                    && $diff->d === 0
-                    && $diff->m === 0
-                    && $diff->y === 0;
+        $intervals = [
+            Precision::YEAR     => 'y',
+            Precision::MONTH    => 'm',
+            Precision::DAY      => 'd',
+            Precision::HOUR     => 'h',
+            Precision::MINUTE   => 'i',
+            Precision::SECOND   => 's'
+        ];
+        $touches = true;
+        $precisionMask = $this->getPrecisionMask();
+        foreach ($intervals as $precision => $interval) {
+            if($precisionMask === $precision){
+                $touches = $touches && $diff->$interval <= 1;
+            } else {
+                $touches = $touches && $diff->$interval === 0;
+            }
         }
-
-        return false;
+        return $touches;
     }
 
     public function startsBefore(DateTimeInterface $date): bool

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -50,6 +50,12 @@ class PeriodTest extends TestCase
             Period::make('2018-01-03', '2018-01-03')
                 ->touchesWith(Period::make('2018-01-01', '2018-01-01'))
         );
+
+        $this->assertFalse(
+            Period::make('2018-01-01 06:30:00', '2018-01-01 07:30:00', Precision::SECOND)
+                ->touchesWith(Period::make('2018-01-01 09:00:00', '2018-01-01 10:00:00', Precision::SECOND))
+        );
+
     }
 
     /**

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -52,6 +52,16 @@ class PeriodTest extends TestCase
         );
 
         $this->assertFalse(
+            Period::make('2018-01-01 06:30:00', '2018-01-01 07:30:00', Precision::HOUR)
+                ->touchesWith(Period::make('2018-01-01 09:00:00', '2018-01-01 10:00:00', Precision::HOUR))
+        );
+
+        $this->assertTrue(
+            Period::make('2018-01-01 06:30:00', '2018-01-01 08:30:00', Precision::HOUR)
+                ->touchesWith(Period::make('2018-01-01 09:00:00', '2018-01-01 10:00:00', Precision::HOUR))
+        );
+
+        $this->assertFalse(
             Period::make('2018-01-01 06:30:00', '2018-01-01 07:30:00', Precision::SECOND)
                 ->touchesWith(Period::make('2018-01-01 09:00:00', '2018-01-01 10:00:00', Precision::SECOND))
         );


### PR DESCRIPTION
Closes #67 

I have updated the tests to add a check with `Precision::SECOND` and confirmed that the updated `touchesWith` method now supports multiple precisions (seconds, days, etc).