### PR TITLE
--fix: PERIOD: Test that periods touch each other based on seconds.

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -159,11 +159,15 @@ class Period implements IteratorAggregate
     {
         $this->ensurePrecisionMatches($period);
 
-        if ($this->getIncludedEnd()->diff($period->getIncludedStart())->days <= 1) {
+        $difference = $this->getIncludedEnd()->diff($period->getIncludedStart());
+
+        if ($difference->days * 86400 + $difference->s <= 0) {
             return true;
         }
 
-        if ($this->getIncludedStart()->diff($period->getIncludedEnd())->days <= 1) {
+        $difference = $this->getIncludedStart()->diff($period->getIncludedEnd());
+
+        if ($difference->days * 86400 + $difference->s <= 0) {
             return true;
         }
 

--- a/src/Period.php
+++ b/src/Period.php
@@ -161,13 +161,13 @@ class Period implements IteratorAggregate
 
         $difference = $this->getIncludedEnd()->diff($period->getIncludedStart());
 
-        if ($difference->days * 86400 + $difference->s <= 0) {
+        if ($difference->days * 86400 + $difference->h * 3600 + $difference->m * 60 + $difference->s <= 0) {
             return true;
         }
 
         $difference = $this->getIncludedStart()->diff($period->getIncludedEnd());
 
-        if ($difference->days * 86400 + $difference->s <= 0) {
+        if ($difference->days * 86400 + $difference->h * 3600 + $difference->m * 60 + $difference->s <= 0) {
             return true;
         }
 

--- a/tests/PeriodCollectionTest.php
+++ b/tests/PeriodCollectionTest.php
@@ -138,7 +138,7 @@ class PeriodCollectionTest extends TestCase
         $collection = new PeriodCollection(
             Period::make('2018-01-01', '2018-01-05', null, Boundaries::EXCLUDE_END),
             Period::make('2018-01-01', '2018-01-05', null, Boundaries::EXCLUDE_END),
-            Period::make('2018-01-01', '2018-01-05', null, Boundaries::EXCLUDE_END),
+            Period::make('2018-01-01', '2018-01-05', null, Boundaries::EXCLUDE_END)
         );
 
         $gaps = $collection->gaps();

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -536,11 +536,19 @@ class PeriodTest extends TestCase
     }
 
     /** @test */
-    public function determine_periods_not_touch_when_they_are_on_the_same_day(){
+    public function determine_periods_not_touch_when_they_are_on_the_same_day_with_second_precision(){
         $a = Period::make('2018-01-01 06:30:00', '2018-01-01 07:30:00', Precision::SECOND);
         $b = Period::make('2018-01-01 09:00:00', '2018-01-01 10:00:00', Precision::SECOND);
 
         $this->assertFalse($a->touchesWith($b));
+    }
+
+    /** @test */
+    public function determine_periods_touch_when_they_are_on_the_same_day_with_default_precision(){
+        $a = Period::make('2018-01-01 06:30:00', '2018-01-01 07:30:00');
+        $b = Period::make('2018-01-01 09:00:00', '2018-01-01 10:00:00');
+
+        $this->assertTrue($a->touchesWith($b));
     }
 
     public function expectedPeriodLengths()

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -32,13 +32,13 @@ class PeriodTest extends TestCase
     public function it_can_determine_if_two_periods_touch_each_other()
     {
         $this->assertTrue(
-            Period::make('2018-01-01', '2018-01-01')
-                ->touchesWith(Period::make('2018-01-02', '2018-01-02'))
+            Period::make('2018-01-01', '2018-01-02')
+                ->touchesWith(Period::make('2018-01-02', '2018-01-03'))
         );
 
         $this->assertTrue(
             Period::make('2018-01-02', '2018-01-02')
-                ->touchesWith(Period::make('2018-01-01', '2018-01-01'))
+                ->touchesWith(Period::make('2018-01-01', '2018-01-02'))
         );
 
         $this->assertFalse(
@@ -248,7 +248,7 @@ class PeriodTest extends TestCase
     {
         $a = Period::make('2018-01-15', '2018-01-31');
 
-        $b = Period::make('2018-02-01', '2018-02-01');
+        $b = Period::make('2018-01-31', '2018-02-01');
 
         $gap = $a->gap($b);
 
@@ -528,7 +528,7 @@ class PeriodTest extends TestCase
     {
         $a = Period::make('2019-02-01', '2019-02-01');
 
-        $b = Period::make('2019-02-02', '2019-02-02');
+        $b = Period::make('2019-02-01', '2019-02-02');
 
         $diff = $a->diff($b);
 

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -535,6 +535,14 @@ class PeriodTest extends TestCase
         $this->assertEmpty($diff);
     }
 
+    /** @test */
+    public function determine_periods_not_touch_when_they_are_on_the_same_day(){
+        $a = Period::make('2018-01-01 06:30:00', '2018-01-01 07:30:00', Precision::SECOND);
+        $b = Period::make('2018-01-01 09:00:00', '2018-01-01 10:00:00', Precision::SECOND);
+
+        $this->assertFalse($a->touchesWith($b));
+    }
+
     public function expectedPeriodLengths()
     {
         return [


### PR DESCRIPTION
Make `touchesWith` to work properly. Previously if the difference between the end and start of the two periods was one day or fewer, it returned true. Now it checks that the two period touches based on difference in seconds.

I had to change some already existing tests, because the tests also relied on that the difference between the periods was one day or fewer.