### PR TITLE
add renew function

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ $period->getEnd(): DateTimeImmutable
 $period->getEndIncluded(): DateTimeImmutable
 ```
 
+#### Renewing a Period
+
+$period = Period::make('2018-01-01', '2018-01-15');
+$renewal = $period->renew(); // '2018-01-16' to '2018-01-31'
+
 #### Comparisons
 
 ```php

--- a/src/Period.php
+++ b/src/Period.php
@@ -93,6 +93,16 @@ class Period implements IteratorAggregate
         );
     }
 
+    public function renew(): Period
+    {
+        $length = $this->includedStart->diff($this->includedEnd);
+
+        $start = $this->includedEnd->add($this->interval);
+        $end = $start->add($length);
+
+        return new self($start, $end, $this->precisionMask, $this->boundaryExclusionMask);
+    }
+
     public function startIncluded(): bool
     {
         return ! $this->startExcluded();

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -19,6 +19,17 @@ class PeriodTest extends TestCase
         $this->assertEquals(15, $period->length());
     }
 
+    /** @test */
+    public function it_can_renew_a_period()
+    {
+        $period = Period::make('2018-01-01', '2018-01-15');
+
+        $rewewal = $period->renew();
+
+        $this->assertTrue($rewewal->touchesWith($period));
+        $this->assertEquals($rewewal->length(), $period->length());
+    }
+
     /**
      * @test
      * @dataProvider overlappingDates


### PR DESCRIPTION
This function allows to repeat or renew a period into the next term. Usage:

```
$period = Period::make('2018-01-01', '2018-01-15');
$rewewal = $period->renew();
```

$renewal will now be from '2018-01-16' to '2018-01-31' (15 days)