### PR TITLE
Add getCeilingEnd method

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ $period->endExcluded(): bool
 
 ```php
 $period->getStart(): DateTimeImmutable
-$period->getStartIncluded(): DateTimeImmutable
+$period->getIncludedStart(): DateTimeImmutable
 $period->getEnd(): DateTimeImmutable
-$period->getEndIncluded(): DateTimeImmutable
+$period->getIncludedEnd(): DateTimeImmutable
+$period->getCeilingEnd(): DateTimeImmutable
 ```
 
 #### Comparisons

--- a/src/Period.php
+++ b/src/Period.php
@@ -133,6 +133,11 @@ class Period implements IteratorAggregate
         return $this->includedEnd;
     }
 
+    public function getCeilingEnd(): DateTimeImmutable
+    {
+        return $this->ceilDate($this->includedEnd, $this->precisionMask);
+    }
+
     public function length(): int
     {
         $length = $this->getIncludedStart()->diff($this->getIncludedEnd())->days + 1;
@@ -521,6 +526,23 @@ class Period implements IteratorAggregate
         $hour = (Precision::HOUR & $precision) === Precision::HOUR ? $hour : '00';
         $minute = (Precision::MINUTE & $precision) === Precision::MINUTE ? $minute : '00';
         $second = (Precision::SECOND & $precision) === Precision::SECOND ? $second : '00';
+
+        return DateTimeImmutable::createFromFormat(
+            'Y m d H i s',
+            implode(' ', [$year, $month, $day, $hour, $minute, $second]),
+            $date->getTimezone()
+        );
+    }
+
+    protected function ceilDate(DateTimeInterface $date, int $precision): DateTimeImmutable
+    {
+        [$year, $month, $day, $hour, $minute, $second] = explode(' ', $date->format('Y m d H i s'));
+
+        $month = (Precision::MONTH & $precision) === Precision::MONTH ? $month : '12';
+        $day = (Precision::DAY & $precision) === Precision::DAY ? $day : cal_days_in_month(CAL_GREGORIAN, $month, $year);
+        $hour = (Precision::HOUR & $precision) === Precision::HOUR ? $hour : '23';
+        $minute = (Precision::MINUTE & $precision) === Precision::MINUTE ? $minute : '59';
+        $second = (Precision::SECOND & $precision) === Precision::SECOND ? $second : '59';
 
         return DateTimeImmutable::createFromFormat(
             'Y m d H i s',

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -35,6 +35,7 @@ class PeriodTest extends TestCase
             [Period::make('2018-01-01 11:30:15', '2018-01-15 11:30:15', Precision::MINUTE), Carbon::make('2018-01-15 11:30:15')->endOfMinute()],
             [Period::make('2018-01-01 11:30:15', '2018-01-15 11:30:15', Precision::HOUR), Carbon::make('2018-01-15 11:30:15')->endOfHour()],
             [Period::make('2018-01-01', '2018-01-15', Precision::DAY), Carbon::make('2018-01-15')->endOfDay()],
+            [Period::make('2018-01-01', '2018-01-15', Precision::DAY, Boundaries::EXCLUDE_END), Carbon::make('2018-01-15')->subDay()->endOfDay()],
             [Period::make('2018-01-01', '2018-01-15', Precision::MONTH), Carbon::make('2018-01-15')->endOfMonth()],
             [Period::make('2018-01-01', '2018-01-15', Precision::YEAR), Carbon::make('2018-01-15')->endOfYear()],
         ];

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -21,6 +21,27 @@ class PeriodTest extends TestCase
 
     /**
      * @test
+     * @dataProvider ceilingDates
+    */
+    public function it_rounds_to_the_end_of_precision(Period $period, Carbon $expected)
+    {
+        $this->assertEquals($expected->startOfSecond(), $period->getCeilingEnd());
+    }
+
+    public function ceilingDates(): array
+    {
+        return [
+            [Period::make('2018-01-01 11:30:15', '2018-01-15 11:30:15', Precision::SECOND), Carbon::make('2018-01-15 11:30:15')->endOfSecond()],
+            [Period::make('2018-01-01 11:30:15', '2018-01-15 11:30:15', Precision::MINUTE), Carbon::make('2018-01-15 11:30:15')->endOfMinute()],
+            [Period::make('2018-01-01 11:30:15', '2018-01-15 11:30:15', Precision::HOUR), Carbon::make('2018-01-15 11:30:15')->endOfHour()],
+            [Period::make('2018-01-01', '2018-01-15', Precision::DAY), Carbon::make('2018-01-15')->endOfDay()],
+            [Period::make('2018-01-01', '2018-01-15', Precision::MONTH), Carbon::make('2018-01-15')->endOfMonth()],
+            [Period::make('2018-01-01', '2018-01-15', Precision::YEAR), Carbon::make('2018-01-15')->endOfYear()],
+        ];
+    }
+
+    /**
+     * @test
      * @dataProvider overlappingDates
      */
     public function it_can_determine_if_two_periods_overlap_with_each_other(Period $a, Period $b)


### PR DESCRIPTION
This PR adds a method to the period class, `getCeilingEnd()` which will round the included end DateTime to the last second of the precision mask.

Useful when using the Period class outside of its context / precision. Getting the end date from the period I would assume to be the last moment within a higher precision.  In my case we have a DAY precision for our period but are persisting into SECOND precision in the database with timezone support etc..

Usage:

```php
$period = Period::make('2018-01-01', '2018-01-15', Precision::DAY);
$period->getIncludedEnd(); // 2018-01-15 00:00:00
$period->getCeilingEnd(); // 2018-01-15 23:59:59
```

```php
$period = Period::make('2018-01-01', '2018-01-15', Precision::DAY, Boundaries::EXCLUDE_END);
$period->getIncludedEnd(); // 2018-01-14 00:00:00
$period->getCeilingEnd(); // 2018-01-14 23:59:59
```

Also small docs fix.