### PR TITLE
Add ceilingEnd method with Precision mask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ phpunit.xml
 vendor
 coverage
 .php_cs.cache
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Next, the `Period` class also has some getters:
 - `includedStart(): DateTimeImmutable`
 - `end(): DateTimeImmutable`
 - `includedEnd(): DateTimeImmutable`
+- `ceilingEnd(Precision::SECOND): DateTimeImmutable`
 - `length(): int`
 - `duration(): PeriodDuration`
 - `precision(): Precision`

--- a/src/Exceptions/CannotCeilLowerPrecision.php
+++ b/src/Exceptions/CannotCeilLowerPrecision.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\Period\Exceptions;
+
+use Exception;
+use Spatie\Period\Precision;
+
+class CannotCeilLowerPrecision extends Exception
+{
+    public static function precisionIsLower(Precision $a, Precision $b): CannotCeilLowerPrecision
+    {
+        $from = self::unitName($a);
+        $to = self::unitName($b);
+
+        return new self("Cannot get the latest $from of a $to.");
+    }
+
+    protected static function unitName(Precision $precision) {
+        return match ($precision->intervalName()) {
+            'y' => 'year',
+            'm' => 'month',
+            'd' => 'day',
+            'h' => 'hour',
+            'i' => 'minute',
+            's' => 'second',
+        };
+    }
+}

--- a/src/Exceptions/CannotCeilLowerPrecision.php
+++ b/src/Exceptions/CannotCeilLowerPrecision.php
@@ -15,7 +15,8 @@ class CannotCeilLowerPrecision extends Exception
         return new self("Cannot get the latest $from of a $to.");
     }
 
-    protected static function unitName(Precision $precision) {
+    protected static function unitName(Precision $precision)
+    {
         return match ($precision->intervalName()) {
             'y' => 'year',
             'm' => 'month',

--- a/src/PeriodTraits/PeriodGetters.php
+++ b/src/PeriodTraits/PeriodGetters.php
@@ -51,8 +51,10 @@ trait PeriodGetters
         return $this->includedEnd;
     }
 
-    public function ceilingEnd(Precision $precision): DateTimeImmutable
+    public function ceilingEnd(?Precision $precision = null): DateTimeImmutable
     {
+        $precision ??= $this->precision;
+
         if ($precision->higherThan($this->precision)) {
             throw CannotCeilLowerPrecision::precisionIsLower($this->precision, $precision);
         }

--- a/src/PeriodTraits/PeriodGetters.php
+++ b/src/PeriodTraits/PeriodGetters.php
@@ -4,6 +4,7 @@ namespace Spatie\Period\PeriodTraits;
 
 use DateTimeImmutable;
 use Spatie\Period\Boundaries;
+use Spatie\Period\Exceptions\CannotCeilLowerPrecision;
 use Spatie\Period\PeriodDuration;
 use Spatie\Period\Precision;
 
@@ -48,6 +49,15 @@ trait PeriodGetters
     public function includedEnd(): DateTimeImmutable
     {
         return $this->includedEnd;
+    }
+
+    public function ceilingEnd(Precision $precision): DateTimeImmutable
+    {
+        if ($precision->higherThan($this->precision)) {
+            throw CannotCeilLowerPrecision::precisionIsLower($this->precision, $precision);
+        }
+
+        return $this->precision->ceilDate($this->includedEnd, $precision);
     }
 
     public function length(): int

--- a/src/Precision.php
+++ b/src/Precision.php
@@ -108,6 +108,23 @@ class Precision
         );
     }
 
+    public function ceilDate(DateTimeInterface $date, Precision $precision): DateTimeImmutable
+    {
+        [$year, $month, $day, $hour, $minute, $second] = explode(' ', $date->format('Y m d H i s'));
+
+        $month = (self::MONTH & $precision->mask) === self::MONTH ? $month : '12';
+        $day = (self::DAY & $precision->mask) === self::DAY ? $day : cal_days_in_month(CAL_GREGORIAN, $month, $year);
+        $hour = (self::HOUR & $precision->mask) === self::HOUR ? $hour : '23';
+        $minute = (self::MINUTE & $precision->mask) === self::MINUTE ? $minute : '59';
+        $second = (self::SECOND & $precision->mask) === self::SECOND ? $second : '59';
+
+        return DateTimeImmutable::createFromFormat(
+            'Y m d H i s',
+            implode(' ', [$year, $month, $day, $hour, $minute, $second]),
+            $date->getTimezone()
+        );
+    }
+
     public function equals(Precision ...$others): bool
     {
         foreach ($others as $other) {
@@ -119,6 +136,11 @@ class Precision
         }
 
         return false;
+    }
+
+    public function higherThan(Precision $other): bool
+    {
+        return strlen($this->dateFormat()) > strlen($other->dateFormat());
     }
 
     public function dateFormat(): string

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -121,7 +121,7 @@ class PeriodTest extends TestCase
      * @test
      * @dataProvider ceilingDates
     */
-    public function it_gets_the_correct_ceiling_of_a_precision(Period $period, Precision $precision, Carbon $expected)
+    public function it_gets_the_correct_ceiling_of_a_precision(Period $period, ?Precision $precision, Carbon $expected)
     {
         $this->assertEquals($expected->startOfSecond(), $period->ceilingEnd($precision));
     }
@@ -163,6 +163,13 @@ class PeriodTest extends TestCase
             Period::make('2018-01-01', '2018-01-15', Precision::YEAR()),
             Precision::YEAR(),
             Carbon::make('2018-01-15')->endOfYear(),
+        ];
+
+        // Test defaults to same precision as period
+        yield [
+            Period::make('2018-01-01', '2018-01-15', Precision::MONTH()),
+            null,
+            Carbon::make('2018-01-15')->endOfMonth(),
         ];
 
         // Test higher precision

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -138,45 +138,45 @@ class PeriodTest extends TestCase
         yield [
             Period::make('2018-01-01 11:30:15', '2018-01-15 11:30:15', Precision::MINUTE()),
             Precision::MINUTE(),
-            Carbon::make('2018-01-15 11:30:15')->endOfMinute()
+            Carbon::make('2018-01-15 11:30:15')->endOfMinute(),
         ];
 
         yield [
             Period::make('2018-01-01 11:30:15', '2018-01-15 11:30:15', Precision::HOUR()),
             Precision::HOUR(),
-            Carbon::make('2018-01-15 11:30:15')->endOfHour()
+            Carbon::make('2018-01-15 11:30:15')->endOfHour(),
         ];
 
         yield [
             Period::make('2018-01-01', '2018-01-15', Precision::DAY()),
             Precision::DAY(),
-            Carbon::make('2018-01-15')->endOfDay()
+            Carbon::make('2018-01-15')->endOfDay(),
         ];
 
         yield [
             Period::make('2018-01-01', '2018-01-15', Precision::MONTH()),
             Precision::MONTH(),
-            Carbon::make('2018-01-15')->endOfMonth()
+            Carbon::make('2018-01-15')->endOfMonth(),
         ];
 
         yield [
             Period::make('2018-01-01', '2018-01-15', Precision::YEAR()),
             Precision::YEAR(),
-            Carbon::make('2018-01-15')->endOfYear()
+            Carbon::make('2018-01-15')->endOfYear(),
         ];
 
         // Test higher precision
         yield [
             Period::make('2018-01-01', '2018-01-15', Precision::DAY()),
             Precision::MONTH(),
-            Carbon::make('2018-01-15')->endOfMonth()
+            Carbon::make('2018-01-15')->endOfMonth(),
         ];
 
         // Test exclusive period
         yield [
             Period::make('2018-01-01', '2018-01-15', Precision::DAY(), Boundaries::EXCLUDE_END()),
             Precision::DAY(),
-            Carbon::make('2018-01-15')->subDay()->endOfDay()
+            Carbon::make('2018-01-15')->subDay()->endOfDay(),
         ];
     }
 

--- a/tests/PrecisionTest.php
+++ b/tests/PrecisionTest.php
@@ -206,4 +206,13 @@ class PrecisionTest extends TestCase
 
         $this->assertEquals(Precision::MINUTE(), $gap->precision());
     }
+
+    /** @test */
+    public function precision_seconds_is_more_precise_than_hours()
+    {
+        $hours = Precision::HOUR();
+        $seconds = Precision::SECOND();
+
+        $this->assertTrue($seconds->higherThan($hours));
+    }
 }


### PR DESCRIPTION
From https://github.com/spatie/period/pull/78

This PR adds a method to the period class, `ceilingEnd(?Precision $precision = null)` which will get the included end DateTime to the last second of the precision passed to this method.

Useful when getting the end date of Period class in a DateTime object - for example if I passed Period::make('2018-01-01', '2018-01-15', Precision::DAY()), I would expect the endDate to be the end of 2018-01-15.. i.e. 23:59:59 that night. 

It defaults to the current Precision of the period if not specified.

Usage:

```php
$period = Period::make('2018-01-01', '2018-01-15', Precision::DAY());
$period->includedEnd(); // 2018-01-15 00:00:00
$period->ceilingEnd(); // 2018-01-15 23:59:59
```

```php
$period = Period::make('2018-01-01', '2018-01-15', Precision::DAY());
$period->includedEnd(); // 2018-01-15 00:00:00
$period->ceilingEnd(Precision::MONTH()); // 2018-01-31 23:59:59
```

```php
$period = Period::make('2018-01-01', '2018-01-15', Precision::DAY, Boundaries::EXCLUDE_END);
$period->includedEnd(); // 2018-01-14 00:00:00
$period->ceilingEnd(); // 2018-01-14 23:59:59
```