### PR TITLE
Reindex collection array after filtering values

### DIFF
--- a/src/PeriodCollection.php
+++ b/src/PeriodCollection.php
@@ -134,7 +134,7 @@ class PeriodCollection implements ArrayAccess, Iterator, Countable
     {
         $collection = clone $this;
 
-        $collection->periods = array_filter($collection->periods, $closure);
+        $collection->periods = array_values(array_filter($collection->periods, $closure));
 
         return $collection;
     }

--- a/tests/PeriodCollectionTest.php
+++ b/tests/PeriodCollectionTest.php
@@ -277,4 +277,25 @@ class PeriodCollectionTest extends TestCase
         $this->assertCount(1, $filtered);
         $this->assertTrue($filtered[0]->equals($collection[0]));
     }
+
+    /** @test */
+    public function it_loops_after_filter()
+    {
+        $collection = new PeriodCollection(
+            Period::make('2018-01-01', '2018-01-02'),
+            Period::make('2018-01-10', '2018-01-15'),
+            Period::make('2018-01-20', '2018-01-25'),
+            Period::make('2018-01-30', '2018-01-31')
+        );
+
+        $filtered = $collection->filter(function (Period $period) {
+            return $period->length() > 2;
+        });
+
+        $items = [];
+        foreach ($filtered as $item) {
+            $items[] = $item;
+        }
+        $this->assertEquals($filtered->count(), count($items));
+    }
 }


### PR DESCRIPTION
`IterableImplementation` relies on a zero-indexed offset; when filtering a collection `$collection->periods` array isn't reindexed, causing collection iteration to stop at the first hole in the index.
Applying `array_values` to `array_filter` results fixes the bug.
`array_values` [performs better](https://stackoverflow.com/questions/57725811/splatpacking-versus-array-values-to-re-index-an-array-with-numeric-keys/57725812#57725812) than splat-packing.