### PR TITLE
Fix subtraction of empty PeriodCollection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to `period` will be documented in this file
 
+## Unreleased
+
+- Fix subtraction of empty PeriodCollection
+
 ## 2.1.1 - 2021-06-11
 
-- reindex collection array after filtering values (#87)
+- Reindex collection array after filtering values (#87)
 
 ## 2.1.0 - 2021-03-24
 

--- a/src/PeriodCollection.php
+++ b/src/PeriodCollection.php
@@ -150,6 +150,10 @@ class PeriodCollection implements ArrayAccess, Iterator, Countable
             $others = new static($others);
         }
 
+        if ($others->count() === 0) {
+            return clone $this;
+        }
+
         $collection = new static();
 
         foreach ($this as $period) {

--- a/tests/PeriodCollectionTest.php
+++ b/tests/PeriodCollectionTest.php
@@ -298,4 +298,21 @@ class PeriodCollectionTest extends TestCase
         }
         $this->assertEquals($filtered->count(), count($items));
     }
+
+    /** @test */
+    public function it_substracts_empty_period_collection()
+    {
+        $collection = new PeriodCollection(
+            Period::make('2018-01-01', '2018-01-02'),
+            Period::make('2018-01-10', '2018-01-15'),
+            Period::make('2018-01-20', '2018-01-25'),
+            Period::make('2018-01-30', '2018-01-31')
+        );
+
+        $emptyCollection = new PeriodCollection();
+
+        $collection->subtract($emptyCollection);
+
+        $this->assertCount(4, $collection);
+    }
 }


### PR DESCRIPTION
When subtracting an empty PeriodCollection from a PeriodCollection an undefined index error occurs.