### PR TITLE
Don't initialize Period::asString in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `period` will be documented in this file
 
+## Unreleased
+
+- Don't initialize Period::asString in constructor
+
 ## 2.1.2 - 2021-10-07
 
 - Fix subtraction of empty PeriodCollection

--- a/src/Period.php
+++ b/src/Period.php
@@ -19,8 +19,6 @@ class Period implements IteratorAggregate
     use PeriodComparisons;
     use PeriodOperations;
 
-    protected string $asString;
-
     protected PeriodDuration $duration;
 
     protected DateTimeImmutable $includedStart;
@@ -43,7 +41,6 @@ class Period implements IteratorAggregate
         $this->includedStart = $boundaries->startIncluded() ? $start : $start->add($this->interval);
         $this->includedEnd = $boundaries->endIncluded() ? $end : $end->sub($this->interval);
         $this->duration = new PeriodDuration($this);
-        $this->asString = $this->resolveString();
     }
 
     public static function make(
@@ -85,30 +82,5 @@ class Period implements IteratorAggregate
         }
 
         throw CannotComparePeriods::precisionDoesNotMatch();
-    }
-
-    private function resolveString(): string
-    {
-        $string = '';
-
-        if ($this->isStartIncluded()) {
-            $string .= '[';
-        } else {
-            $string .= '(';
-        }
-
-        $string .= $this->start()->format($this->precision->dateFormat());
-
-        $string .= ',';
-
-        $string .= $this->end()->format($this->precision->dateFormat());
-
-        if ($this->isEndIncluded()) {
-            $string .= ']';
-        } else {
-            $string .= ')';
-        }
-
-        return $string;
     }
 }

--- a/src/PeriodTraits/PeriodGetters.php
+++ b/src/PeriodTraits/PeriodGetters.php
@@ -11,6 +11,8 @@ use Spatie\Period\Precision;
 /** @mixin \Spatie\Period\Period */
 trait PeriodGetters
 {
+    protected string $asString;
+
     public function isStartIncluded(): bool
     {
         return $this->boundaries->startIncluded();
@@ -106,6 +108,35 @@ trait PeriodGetters
 
     public function asString(): string
     {
+        if (!isset($this->asString)) {
+            $this->asString = $this->resolveString();
+        }
+
         return $this->asString;
+    }
+
+    private function resolveString(): string
+    {
+        $string = '';
+
+        if ($this->isStartIncluded()) {
+            $string .= '[';
+        } else {
+            $string .= '(';
+        }
+
+        $string .= $this->start()->format($this->precision->dateFormat());
+
+        $string .= ',';
+
+        $string .= $this->end()->format($this->precision->dateFormat());
+
+        if ($this->isEndIncluded()) {
+            $string .= ']';
+        } else {
+            $string .= ')';
+        }
+
+        return $string;
     }
 }


### PR DESCRIPTION
When working with large PeriodCollections (300-400 Period objects each) initializing asString variable in Period __construct() slows down PeriodCollection operation as subtract() and overlapAll().
With this patch, I've obtained a -16% CPU time in my batch command (going from 4min 35sec to 3min 51sec).

<img width="1401" alt="Schermata 2021-10-06 alle 18 59 11" src="https://user-images.githubusercontent.com/28512/136250308-eff99a07-5179-4531-be40-ce459eb6ec82.png">

