### PR TITLE
Filter duplicate periods in collection

### DIFF
--- a/src/PeriodCollection.php
+++ b/src/PeriodCollection.php
@@ -179,4 +179,14 @@ class PeriodCollection implements ArrayAccess, Iterator, Countable
 
         return $overlaps;
     }
+
+    public function unique(): PeriodCollection
+    {
+        $uniquePeriods = [];
+        foreach ($this->periods as $period) {
+            $uniquePeriods[$period->asString()] = $period;
+        }
+
+        return new static(...array_values($uniquePeriods));
+    }
 }

--- a/tests/PeriodCollectionTest.php
+++ b/tests/PeriodCollectionTest.php
@@ -315,4 +315,24 @@ class PeriodCollectionTest extends TestCase
 
         $this->assertCount(4, $collection);
     }
+
+    /** @test */
+    public function it_filters_duplicate_periods_in_collection()
+    {
+        $collection = new PeriodCollection(
+            Period::make('2018-01-01', '2018-01-02'),
+            Period::make('2018-01-01', '2018-01-02'),
+            Period::make('2018-01-01', '2018-01-02'),
+            Period::make('2018-01-01', '2018-01-02'),
+            Period::make('2018-01-01', '2018-01-02'),
+            Period::make('2018-01-30', '2018-01-31')
+        );
+
+        $unique = $collection->unique();
+
+        $this->assertCount(6, $collection);
+        $this->assertCount(2, $unique);
+        $this->assertTrue($unique[0]->equals($collection[0]));
+        $this->assertTrue($unique[1]->equals($collection[5]));
+    }
 }


### PR DESCRIPTION
When we add a `Period` in a collection or create a new `PeriodCollection` from an array of `Period` they are added as is.

`unique()` deduplicates `PeriodCollection->periods` array, returning a new collection.