### PR TITLE
Add PHP 8.1 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0, 8.1]
+                php: [8.1, 8.0]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "larapack/dd": "^1.0",
-        "nesbot/carbon": "^2.40",
-        "phpunit/phpunit": "^8.5.21",
-        "spatie/ray": "^1.20"
+        "larapack/dd": "^1.1",
+        "nesbot/carbon": "^2.54",
+        "phpunit/phpunit": "^9.5",
+        "spatie/ray": "^1.31"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds PHP 8.1 support to the tests workflow.  It also bumps dependency versions to their latest, including using `PHPUnit` v9 instead of v8.

_This repo needs the primary branch renamed from `master` to `main`._