### PR TITLE
Error "Undefined array key 0" fix

### DIFF
--- a/src/PeriodTraits/PeriodOperations.php
+++ b/src/PeriodTraits/PeriodOperations.php
@@ -38,7 +38,9 @@ trait PeriodOperations
 
     public function overlap(Period ...$others): ?static
     {
-        if (count($others) > 1) {
+        if (count($others) === 0) {
+            return null;
+        } else if (count($others) > 1) {
             return $this->overlapAll(...$others);
         } else {
             $other = $others[0];
@@ -115,7 +117,9 @@ trait PeriodOperations
      */
     public function subtract(Period ...$others): PeriodCollection
     {
-        if (count($others) > 1) {
+        if (count($others) === 0)
+            return PeriodCollection::make($this);
+        } else if (count($others) > 1) {
             return $this->subtractAll(...$others);
         } else {
             $other = $others[0];

--- a/src/PeriodTraits/PeriodOperations.php
+++ b/src/PeriodTraits/PeriodOperations.php
@@ -117,7 +117,7 @@ trait PeriodOperations
      */
     public function subtract(Period ...$others): PeriodCollection
     {
-        if (count($others) === 0)
+        if (count($others) === 0) {
             return PeriodCollection::make($this);
         } else if (count($others) > 1) {
             return $this->subtractAll(...$others);

--- a/tests/Operations/OverlapTest.php
+++ b/tests/Operations/OverlapTest.php
@@ -5,6 +5,7 @@ namespace Spatie\Period\Tests\Operations;
 use Generator;
 use PHPUnit\Framework\TestCase;
 use Spatie\Period\Period;
+use Spatie\Period\PeriodCollection;
 
 class OverlapTest extends TestCase
 {
@@ -177,5 +178,16 @@ class OverlapTest extends TestCase
          * B    [===]
          */
         yield [Period::make('2018-02-01', '2018-02-28'), Period::make('2018-01-01', '2018-01-31')];
+    }
+
+    /** @test */
+    public function passing_empty_period_collection_returns_null()
+    {
+        $current = Period::make('2018-01-01', '2018-01-31');
+        $emptyCollection = new PeriodCollection;
+
+        $diff = $current->overlap(... $emptyCollection);
+
+        $this->assertNull($diff);
     }
 }

--- a/tests/Operations/SubtractTest.php
+++ b/tests/Operations/SubtractTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Period\Tests\Operations;
 
 use PHPUnit\Framework\TestCase;
 use Spatie\Period\Period;
+use Spatie\Period\PeriodCollection;
 
 class SubtractTest extends TestCase
 {
@@ -222,5 +223,18 @@ class SubtractTest extends TestCase
         $this->assertTrue($diff[0]->equals(Period::make('2018-01-01', '2018-01-04')));
         $this->assertTrue($diff[1]->equals(Period::make('2018-01-11', '2018-01-14')));
         $this->assertTrue($diff[2]->equals(Period::make('2018-01-21', '2018-01-31')));
+    }
+
+    /** @test */
+    public function passing_empty_period_collection_returns_same_period_within_collection()
+    {
+        $current = Period::make('2018-01-01', '2018-01-31');
+        $emptyCollection = new PeriodCollection;
+
+        $diff = $current->subtract(... $emptyCollection);
+
+        $this->assertInstanceOf(PeriodCollection::class, $diff);
+        $this->assertCount(1, $diff);
+        $this->assertTrue($diff[0]->equals($current));
     }
 }


### PR DESCRIPTION
There's an error, if you pass an empty PeriodCollection to `overlap()` or `subtract()` method since there's no check whether the collection actually has any values.

Steps to reproduce:
```php

        $period = Period::make('2021-12-31', '2022-01-01');
        $collection = new PeriodCollection;

        $period->overlap(... $collection); // Throws ErrorException "Undefined array key 0"
        $period->subtract(... $collection); // Throws ErrorException "Undefined array key 0"
```

P.S. Thank you for your products and Merry Christmas! :)