### PR TITLE
Add uniqueIntervals Method for Non-Overlapping Interval Calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,31 @@ Merges all periods in collection with overlapping ranges.
 
 ![](./docs/img/collection-union.png)
 
+### `uniqueIntervals(): static`
+
+Returns a collection of unique, non-overlapping intervals by breaking down overlapping or intersecting periods within the original collection.
+
+This method is helpful when you want to understand distinct time ranges across multiple periods without overlapping segments. It iterates through all periods in the collection and recursively splits them until all overlapping sections are fully separated, resulting in a collection of unique, non-overlapping intervals.
+
+```php
+$periods = new PeriodCollection(
+        Period::make('2024-08-01', '2024-08-05'),
+        Period::make('2024-08-03', '2024-08-07'),
+        Period::make('2024-08-06', '2024-08-10')
+    );
+
+$uniqueIntervals = $periods->uniqueIntervals()->sort();
+
+foreach ($uniqueIntervals as $interval) {
+    echo $interval->start()->format('Y-m-d') . ' - ' . $interval->end()->format('Y-m-d') . PHP_EOL;
+}
+
+// Output:
+// 2024-08-01 - 2024-08-02
+// 2024-08-03 - 2024-08-05
+// 2024-08-06 - 2024-08-07
+// 2024-08-08 - 2024-08-10
+```
 ---
 
 Finally, there are a few utility methods available on `PeriodCollection` as well:

--- a/tests/PeriodCollectionTest.php
+++ b/tests/PeriodCollectionTest.php
@@ -305,3 +305,110 @@ it('unions collection', function () {
     expect($unioned[2]->start() == $collection[3]->start())->toBeTrue();
     expect($unioned[2]->end() == $collection[4]->end())->toBeTrue();
 });
+
+/**
+ * Given periods:
+ *
+ * A          [==========]
+ * B               [==========]
+ * C                       [==========]
+ * OVERLAP    [==] [=====] [==]  [====]
+ */
+it('can determine unique non-overlapping intervals from overlapping periods', function () {
+    $periods = new PeriodCollection(
+        Period::make('2024-08-01', '2024-08-05'),
+        Period::make('2024-08-03', '2024-08-07'),
+        Period::make('2024-08-06', '2024-08-10')
+    );
+
+    $uniqueIntervals = $periods->uniqueIntervals();
+    $uniqueIntervals = $uniqueIntervals->sort();
+
+    expect($uniqueIntervals)->toHaveCount(4);
+
+    expect($uniqueIntervals[0]->equals(Period::make('2024-08-01', '2024-08-02')))->toBeTrue();
+    expect($uniqueIntervals[1]->equals(Period::make('2024-08-03', '2024-08-05')))->toBeTrue();
+    expect($uniqueIntervals[2]->equals(Period::make('2024-08-06', '2024-08-07')))->toBeTrue();
+    expect($uniqueIntervals[3]->equals(Period::make('2024-08-08', '2024-08-10')))->toBeTrue();
+});
+
+/**
+ * Given periods:
+ *
+ * A          [=====]
+ * B              [====]
+ * C                  [=====]
+ *
+ * Expected unique intervals:
+ *
+ * Result     [==][==][=][==]
+ */
+it('can handle unique intervals from partially overlapping periods', function () {
+    $periods = new PeriodCollection(
+        Period::make('2024-08-01', '2024-08-04'),
+        Period::make('2024-08-03', '2024-08-05'),
+        Period::make('2024-08-05', '2024-08-07')
+    );
+
+    $uniqueIntervals = $periods->uniqueIntervals();
+    $uniqueIntervals = $uniqueIntervals->sort();
+
+    expect($uniqueIntervals)->toHaveCount(4);
+
+    expect($uniqueIntervals[0]->equals(Period::make('2024-08-01', '2024-08-02')))->toBeTrue();
+    expect($uniqueIntervals[1]->equals(Period::make('2024-08-03', '2024-08-04')))->toBeTrue();
+    expect($uniqueIntervals[2]->equals(Period::make('2024-08-05', '2024-08-05')))->toBeTrue();
+    expect($uniqueIntervals[3]->equals(Period::make('2024-08-06', '2024-08-07')))->toBeTrue();
+});
+
+/**
+ * Given periods:
+ *
+ * A        [==========]
+ * B           [===]
+ *
+ * Expected unique intervals:
+ *
+ * Result   [==][===][=====]
+ */
+it('can handle unique intervals from a period that fully contains another period', function () {
+    $periods = new PeriodCollection(
+        Period::make('2024-08-01', '2024-08-10'),
+        Period::make('2024-08-03', '2024-08-05')
+    );
+
+    $uniqueIntervals = $periods->uniqueIntervals();
+    $uniqueIntervals = $uniqueIntervals->sort();
+
+    expect($uniqueIntervals)->toHaveCount(3);
+
+    expect($uniqueIntervals[0]->equals(Period::make('2024-08-01', '2024-08-02')))->toBeTrue();
+    expect($uniqueIntervals[1]->equals(Period::make('2024-08-03', '2024-08-05')))->toBeTrue();
+    expect($uniqueIntervals[2]->equals(Period::make('2024-08-06', '2024-08-10')))->toBeTrue();
+});
+
+/**
+ * Given periods:
+ *
+ * A        [===]
+ * B               [===]
+ * C                       [===]
+ *
+ * Expected unique intervals (no changes since they're non-overlapping):
+ *
+ * Result   [===]  [===]  [===]
+ */
+it('unique intervals returns non-overlapping periods as they are', function () {
+    $periods = new PeriodCollection(
+        Period::make('2024-08-01', '2024-08-03'),
+        Period::make('2024-08-05', '2024-08-07'),
+        Period::make('2024-08-09', '2024-08-11')
+    );
+
+    $uniqueIntervals = $periods->uniqueIntervals();
+    $uniqueIntervals = $uniqueIntervals->sort();
+
+    expect($uniqueIntervals[0]->equals(Period::make('2024-08-01', '2024-08-03')))->toBeTrue();
+    expect($uniqueIntervals[1]->equals(Period::make('2024-08-05', '2024-08-07')))->toBeTrue();
+    expect($uniqueIntervals[2]->equals(Period::make('2024-08-09', '2024-08-11')))->toBeTrue();
+});


### PR DESCRIPTION
**Problem:**

When working with multiple overlapping periods, I faced a challenge in breaking down these intervals into unique, non-overlapping segments. Existing methods in the library were not sufficient to address this scenario, especially when multiple periods partially overlap or fully contain each other.

For example, given the following intervals:

	•	Period A: August 1, 2024 - August 5, 2024
	•	Period B: August 3, 2024 - August 7, 2024
	•	Period C: August 6, 2024 - August 10, 2024

The desired result would be a collection of distinct, non-overlapping intervals:

	•	August 1, 2024 - August 2, 2024
	•	August 3, 2024 - August 5, 2024
	•	August 6, 2024 - August 7, 2024
	•	August 8, 2024 - August 10, 2024

In this case, the overlapping segments needed to be separated to provide a clear view of all unique time intervals.

**_Solution:_**

This pull request introduces a new uniqueIntervals method to the PeriodCollection class, which generates a collection of non-overlapping intervals from any set of overlapping or intersecting periods. The method recursively breaks down intervals until all overlaps are resolved, resulting in distinct intervals that fully represent the original periods without overlaps.

The solution includes:

• **uniqueIntervals()** Method: A public method that initiates the process of breaking down overlapping intervals into unique segments.
• **Recursive Processing**: An internal **processIntervalsRecursively()** function that iterates over each period, identifies overlaps, and recursively splits intervals as necessary. This ensures that all possible overlaps are handled and only unique intervals remain.